### PR TITLE
chore: Ignore backstage and react packages in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^@backstage/", "^react", "@types/react"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Backstage has its own upgrade mechanism that we will use to update its dependencies etc. along with required manual work.

For now we'll let React stay aligned with that.

### Description of changes

Added package rule to renovatebot configuration to ignore these packages.

### Description of how you validated changes



### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
