### PR TITLE
fix: export plugins as default for new backstage backend

### DIFF
--- a/plugins/codebuild/backend/src/index.ts
+++ b/plugins/codebuild/backend/src/index.ts
@@ -12,3 +12,4 @@
  */
 
 export * from './service/router';
+export { awsCodebuildPlugin as default } from './plugin';

--- a/plugins/codebuild/backend/src/plugin.ts
+++ b/plugins/codebuild/backend/src/plugin.ts
@@ -20,7 +20,7 @@ import { createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import { DefaultAwsCodeBuildService } from './service/DefaultAwsCodeBuildService';
 
-export const awsCodePiplinePlugin = createBackendPlugin({
+export const awsCodebuildPlugin = createBackendPlugin({
   pluginId: 'aws-codebuild',
   register(env) {
     env.registerInit({

--- a/plugins/codepipeline/backend/src/index.ts
+++ b/plugins/codepipeline/backend/src/index.ts
@@ -12,3 +12,4 @@
  */
 
 export * from './service/router';
+export { awsCodePiplinePlugin as default } from './plugin';

--- a/plugins/ecs/backend/src/index.ts
+++ b/plugins/ecs/backend/src/index.ts
@@ -12,3 +12,4 @@
  */
 
 export * from './service/router';
+export { amazonEcsPlugin as default } from './plugin';


### PR DESCRIPTION
### Issue # (if applicable)

### Reason for this change

To make these plugins work with the new Backstage backend system

### Description of changes

Export plugin as default from index.ts

### Description of how you validated changes

No need

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
