### PR TITLE
feat: Added auth policy for health check endpoints

### DIFF
--- a/plugins/codebuild/backend/src/plugin.ts
+++ b/plugins/codebuild/backend/src/plugin.ts
@@ -63,6 +63,10 @@ export const awsCodebuildPlugin = createBackendPlugin({
             httpAuth,
           }),
         );
+        httpRouter.addAuthPolicy({
+          path: '/health',
+          allow: 'unauthenticated',
+        });
       },
     });
   },

--- a/plugins/codepipeline/backend/src/plugin.ts
+++ b/plugins/codepipeline/backend/src/plugin.ts
@@ -61,6 +61,10 @@ export const awsCodePiplinePlugin = createBackendPlugin({
             httpAuth,
           }),
         );
+        httpRouter.addAuthPolicy({
+          path: '/health',
+          allow: 'unauthenticated',
+        });
       },
     });
   },

--- a/plugins/ecs/backend/src/plugin.ts
+++ b/plugins/ecs/backend/src/plugin.ts
@@ -60,6 +60,10 @@ export const amazonEcsPlugin = createBackendPlugin({
             httpAuth,
           }),
         );
+        httpRouter.addAuthPolicy({
+          path: '/health',
+          allow: 'unauthenticated',
+        });
       },
     });
   },


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

New authentication changes to Backstage mean that health check endpoint is inaccessible without auth policy change to allow unauthenticated access.

### Description of changes

Added unauthenticated auth policy for health check path in each plugin backend:

```typescript
httpRouter.addAuthPolicy({
          path: '/health',
          allow: 'unauthenticated',
        });
```

### Description of how you validated changes

Local testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
