### PR TITLE
fix: S3 cp action should use path as provided

### DIFF
--- a/plugins/core/scaffolder-actions/package.json
+++ b/plugins/core/scaffolder-actions/package.json
@@ -38,18 +38,19 @@
     "@backstage/errors": "^1.2.4",
     "@backstage/integration-aws-node": "^0.1.12",
     "@backstage/plugin-scaffolder-node": "^0.4.2",
-    "@backstage/plugin-scaffolder-node-test-utils": "^0.1.2",
     "fs-extra": "^11.2.0",
     "glob": "^10.3.10",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "^0.3.6",
     "@backstage/cli": "^0.26.2",
     "@backstage/config": "^1.2.0",
+    "@backstage/plugin-scaffolder-node-test-utils": "^0.1.2",
     "@types/fs-extra": "^11",
     "@types/glob": "^7.2.0",
     "aws-sdk-client-mock": "^4.0.0",
-    "mock-fs": "^5.2.0"
+    "aws-sdk-client-mock-jest": "^4.0.0"
   },
   "files": [
     "dist"

--- a/plugins/core/scaffolder-actions/src/actions/s3/cp.test.ts
+++ b/plugins/core/scaffolder-actions/src/actions/s3/cp.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createAwsS3CpAction } from './cp';
+import { createMockDirectory } from '@backstage/backend-test-utils';
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DefaultAwsCredentialsManager,
+  AwsCredentialProvider,
+  AwsCredentialProviderOptions,
+} from '@backstage/integration-aws-node';
+import { ConfigReader } from '@backstage/config';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import 'aws-sdk-client-mock-jest';
+
+const s3Mock = mockClient(S3Client);
+
+function getMockCredentialProvider(): Promise<AwsCredentialProvider> {
+  return Promise.resolve({
+    sdkCredentialProvider: async () => {
+      return Promise.resolve({
+        accessKeyId: 'MY_ACCESS_KEY_ID',
+        secretAccessKey: 'MY_SECRET_ACCESS_KEY',
+      });
+    },
+  });
+}
+const getCredProviderMock = jest.spyOn(
+  DefaultAwsCredentialsManager.prototype,
+  'getCredentialProvider',
+);
+
+const mockDir = createMockDirectory({ mockOsTmpDir: true });
+const mockTmpDir = mockDir.path;
+
+describe('testing', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    s3Mock.reset();
+    getCredProviderMock.mockImplementation((_?: AwsCredentialProviderOptions) =>
+      getMockCredentialProvider(),
+    );
+    mockDir.setContent({
+      dir1: {
+        'test-file.json': '{}',
+        'test-file-again.json': '{}',
+      },
+      dir2: {
+        'test-file.json': '{}',
+      },
+    });
+  });
+
+  const config = new ConfigReader({});
+
+  const action = createAwsS3CpAction({
+    credsManager: DefaultAwsCredentialsManager.fromConfig(config),
+  });
+
+  const mockContext = createMockActionContext({
+    input: {
+      bucketName: 'test-bucket',
+    },
+    workspacePath: mockTmpDir,
+  });
+
+  it('copies the workspace', async () => {
+    await action.handler(mockContext);
+
+    expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'dir1/test-file.json',
+    });
+
+    expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'dir1/test-file-again.json',
+    });
+  });
+
+  it('copies a file', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        path: 'dir1/test-file.json',
+      },
+    });
+
+    expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'dir1/test-file.json',
+    });
+  });
+
+  it('copies a file with prefix', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        path: 'dir1/test-file.json',
+        prefix: 'test/',
+      },
+    });
+
+    expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'test/dir1/test-file.json',
+    });
+  });
+
+  it('copies a directory', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        path: 'dir1/**',
+      },
+    });
+
+    expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
+      Bucket: 'test-bucket',
+      Key: 'dir1/test-file.json',
+    });
+  });
+});

--- a/plugins/core/scaffolder-actions/src/actions/s3/cp.ts
+++ b/plugins/core/scaffolder-actions/src/actions/s3/cp.ts
@@ -17,7 +17,7 @@ import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
-import fs, { createReadStream } from 'fs-extra';
+import fs from 'fs-extra';
 import { z } from 'zod';
 import { resolveSafeChildPath } from '@backstage/backend-common';
 import { glob } from 'glob';
@@ -72,9 +72,7 @@ export const createAwsS3CpAction = (options: {
       }
 
       const files = glob
-        .sync(
-          resolveSafeChildPath(ctx.workspacePath, path ? `${path}/**` : '**'),
-        )
+        .sync(resolveSafeChildPath(ctx.workspacePath, path ? path : '**'))
         .filter(filePath => fs.lstatSync(filePath).isFile());
 
       const client = new S3Client({
@@ -89,7 +87,7 @@ export const createAwsS3CpAction = (options: {
             new PutObjectCommand({
               Bucket: bucketName,
               Key: prefix + file.replace(`${ctx.workspacePath}/`, ''),
-              Body: createReadStream(file),
+              Body: fs.readFileSync(file).toString(),
             }),
           );
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,6 +2119,7 @@ __metadata:
     "@aws-sdk/types": "npm:^3.511.0"
     "@backstage/backend-common": "npm:^0.21.6"
     "@backstage/backend-plugin-api": "npm:^0.6.16"
+    "@backstage/backend-test-utils": "npm:^0.3.6"
     "@backstage/cli": "npm:^0.26.2"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/errors": "npm:^1.2.4"
@@ -2128,9 +2129,9 @@ __metadata:
     "@types/fs-extra": "npm:^11"
     "@types/glob": "npm:^7.2.0"
     aws-sdk-client-mock: "npm:^4.0.0"
+    aws-sdk-client-mock-jest: "npm:^4.0.0"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
-    mock-fs: "npm:^5.2.0"
     zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
@@ -14888,6 +14889,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aws-sdk-client-mock-jest@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "aws-sdk-client-mock-jest@npm:4.0.0"
+  dependencies:
+    expect: "npm:>28.1.3"
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    aws-sdk-client-mock: 4.0.0
+  checksum: 10c0/fac0ff3e5d6c6044727cf72ded29db3eb0e40bf92877a1ed83c60dac3b7fb1322cdf8a4775b2475bc661aad847f3b36db331c9f52da1e2e5680b79d1f848f68c
+  languageName: node
+  linkType: hard
+
 "aws-sdk-client-mock@npm:^4.0.0":
   version: 4.0.0
   resolution: "aws-sdk-client-mock@npm:4.0.0"
@@ -19239,7 +19252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.0.0, expect@npm:^29.7.0":
+"expect@npm:>28.1.3, expect@npm:^29.0.0, expect@npm:^29.7.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
   dependencies:
@@ -25455,13 +25468,6 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
-  languageName: node
-  linkType: hard
-
-"mock-fs@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "mock-fs@npm:5.2.0"
-  checksum: 10c0/e917e71295ee9d805c7d9ab0214a66658db0212f35731ba0c75dc1ccbb9964e6787a6d725561f05fcf569c64cf4a1176f5ce438f98b009227520f646f8abf174
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The S3 cp action should use the `path` option as provided instead of adding wildcards to it.

### Description of changes

Pass through path option directly

### Description of how you validated changes

Added unit tests for this and other scenarios.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
