### PR TITLE
fix(docs): type key missing on resourceTaggingApi example

### DIFF
--- a/docs/locating-resources.md
+++ b/docs/locating-resources.md
@@ -38,6 +38,7 @@ This resource locator is used by default and does not require any configuration.
 ```yaml
 aws:
   locator:
+    type: resourceTaggingApi
     resourceTaggingApi:
       # Add each additional AWS account you wish to search
       accounts:


### PR DESCRIPTION
### Issue # (if applicable)
/
Closes #/

### Reason for this change
The example in the docs for the resourceTaggingApi were missing a type key, so it didnt work.

### Description of changes
Adding a line of documentation

### Description of how you validated changes
/ 
### Checklist

- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
