### PR TITLE
fix: Resource locator type should be optional

### DIFF
--- a/plugins/core/common/src/locator/resource-locator-factory.ts
+++ b/plugins/core/common/src/locator/resource-locator-factory.ts
@@ -28,7 +28,7 @@ export class AwsResourceLocatorFactory {
     const conf = config.getOptionalConfig('aws.locator');
 
     if (conf) {
-      const locatorType = conf.get('type');
+      const locatorType = conf.getOptionalString('type');
 
       switch (locatorType) {
         case 'resourceExplorer':


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

The resource locator type configuration option was intended to be optional, but the lookup using the config API treats it as required. If the value is missing an error will occur.

### Description of changes

Used `getOptionalString()` instead of `get()` to retrieve the value.

### Description of how you validated changes

Ran tests and manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
