### PR TITLE
feat: Support for multiple accounts and regions in resource tagging locator

### DIFF
--- a/docs/locating-resources.md
+++ b/docs/locating-resources.md
@@ -11,11 +11,11 @@ The mechanism documented here is designed to provide this functionality.
 
 There are three resource locator mechanisms available:
 
-| Name                   | Description                               |
-| ---------------------- | ----------------------------------------- |
-| `resource-tagging-api` | Using the AWS Resource Groups Tagging API |
-| `resource-explorer`    | Using the AWS Resource Explorer API       |
-| `aws-config`           | Using the AWS Config service              |
+| Name                 | Description                                         |
+| -------------------- | --------------------------------------------------- |
+| `resourceTaggingApi` | (Default) Using the AWS Resource Groups Tagging API |
+| `resourceExplorer`   | Using the AWS Resource Explorer API                 |
+| `awsConfig`          | Using the AWS Config service                        |
 
 By default plugins will use the [AWS Resource Groups Tagging API](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/overview.html) to locate resource in the same AWS account that Backstage is running. This requires no configuration on the part of the Backstage administrator and will work for simpler setups, for example within a single account.
 
@@ -33,17 +33,19 @@ The section details how to setup and configure the various resource locator mech
 
 ### Resource Tagging API
 
-This resource locator is used by default and does not require any configuration. By default it will query the API using the AWS account based on the IAM credentials provided to Backstage and the default region provided (for example with `AWS_REGION`/`AWS_DEFAULT_REGION`). However, if you wish to extend this to multiple AWS regions/accounts you can provide additional configuration:
+This resource locator is used by default and does not require any configuration. By default it will query the API using the AWS account based on the IAM credentials provided to Backstage and the default region provided (for example with `AWS_REGION`/`AWS_DEFAULT_REGION`).
+
+If you wish to extend this to multiple AWS regions/accounts you can provide additional configuration:
 
 ```yaml
 aws:
   locator:
     resourceTaggingApi:
-      # Add each additional AWS account you wish to search
+      # Add each AWS account you wish to search
       accounts:
-        - 1111111111
-        - 2222222222
-      # Add each additional AWS region you wish to search
+        - '1111111111'
+        - '2222222222'
+      # Add each AWS region you wish to search
       regions:
         - us-east-1
         - eu-west-2

--- a/plugins/core/common/src/locator/resource-tagging-api-instance.ts
+++ b/plugins/core/common/src/locator/resource-tagging-api-instance.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  GetResourcesCommand,
+  ResourceGroupsTaggingAPIClient,
+} from '@aws-sdk/client-resource-groups-tagging-api';
+import { Logger } from 'winston';
+import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
+import { convertResourceTypeString, parseResourceLocatorTags } from './utils';
+
+export class AwsResourceTaggingApiLocatorInstance {
+  public constructor(
+    private readonly logger: Logger,
+    private readonly client: ResourceGroupsTaggingAPIClient,
+  ) {}
+
+  static async create(options: {
+    credsManager: DefaultAwsCredentialsManager;
+    accountId: string | undefined;
+    region: string | undefined;
+    logger: Logger;
+  }): Promise<AwsResourceTaggingApiLocatorInstance> {
+    let credentialProvider: AwsCredentialIdentityProvider;
+
+    const { accountId, region, credsManager } = options;
+
+    if (accountId) {
+      credentialProvider = (
+        await credsManager.getCredentialProvider({
+          accountId: accountId,
+        })
+      ).sdkCredentialProvider;
+    } else {
+      credentialProvider = (await credsManager.getCredentialProvider())
+        .sdkCredentialProvider;
+    }
+
+    const client = new ResourceGroupsTaggingAPIClient({
+      region: region,
+      customUserAgent: 'aws-resourcetaggingapi-plugin-for-backstage',
+      credentialDefaultProvider: () => credentialProvider,
+    });
+
+    return new AwsResourceTaggingApiLocatorInstance(options.logger, client);
+  }
+
+  async getResourceArns({
+    resourceType,
+    tagString,
+  }: {
+    resourceType: string;
+    tagString: string;
+  }): Promise<string[]> {
+    const TagFilters = parseResourceLocatorTags(tagString).map(e => {
+      return {
+        Key: e.key,
+        Values: [e.value],
+      };
+    });
+
+    const convertedResourceType = convertResourceTypeString(resourceType);
+
+    this.logger.debug(`Retrieving resource ARNs for ${convertedResourceType}`);
+
+    const response = await this.client.send(
+      new GetResourcesCommand({
+        ResourceTypeFilters: [convertedResourceType],
+        TagFilters,
+      }),
+    );
+
+    return response.ResourceTagMappingList!.map(e => e.ResourceARN!);
+  }
+}


### PR DESCRIPTION
### Issue # (if applicable)

Closes #78 

### Reason for this change

The resource tagging locator mechanism should be able to work across multiple accounts and regions to facilitate setups where Resource Explorer or Config are not practical. This would allow resources to be looked up by tags across accounts and regions.

### Description of changes

If no additional configuration is provided the locator will continue to behave as before.

Its now possible to optionally configure additional accounts and regions where the resource tagging API will be used to look up resources by tags. This looks like so:

```yaml
aws:
  locator:
    resourceTaggingApi:
      # Add each AWS account you wish to search
      accounts:
        - '1111111111'
        - '2222222222'
      # Add each AWS region you wish to search
      regions:
        - us-east-1
        - eu-west-2
```

### Description of how you validated changes

Added unit test for multiple regions since this can be verified through existing mock patterns. Currently no unit tests for multiple accounts, this was validated manually.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
