### PR TITLE
fix: Consistent user agent header for all AWS API calls

### DIFF
--- a/plugins/codebuild/backend/src/service/DefaultAwsCodeBuildService.ts
+++ b/plugins/codebuild/backend/src/service/DefaultAwsCodeBuildService.ts
@@ -18,6 +18,7 @@ import {
   AwsResourceLocatorFactory,
   AwsResourceLocator,
   getOneOfEntityAnnotations,
+  AWS_SDK_CUSTOM_USER_AGENT,
 } from '@aws/aws-core-plugin-for-backstage-common';
 import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import {
@@ -193,7 +194,7 @@ export class DefaultAwsCodeBuildService implements AwsCodeBuildService {
 
     return new CodeBuildClient({
       region: region,
-      customUserAgent: 'aws-codebuild-plugin-for-backstage',
+      customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
       credentialDefaultProvider: () => credentialProvider.sdkCredentialProvider,
     });
   }

--- a/plugins/codepipeline/backend/src/service/DefaultAwsCodePipelineService.ts
+++ b/plugins/codepipeline/backend/src/service/DefaultAwsCodePipelineService.ts
@@ -18,6 +18,7 @@ import {
   AwsResourceLocatorFactory,
   AwsResourceLocator,
   getOneOfEntityAnnotations,
+  AWS_SDK_CUSTOM_USER_AGENT,
 } from '@aws/aws-core-plugin-for-backstage-common';
 import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import {
@@ -240,7 +241,7 @@ export class DefaultAwsCodePipelineService implements AwsCodePipelineService {
 
     return new CodePipelineClient({
       region: region,
-      customUserAgent: 'aws-codepipeline-plugin-for-backstage',
+      customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
       credentialDefaultProvider: () => credentialProvider.sdkCredentialProvider,
     });
   }

--- a/plugins/core/common/src/constants.ts
+++ b/plugins/core/common/src/constants.ts
@@ -11,6 +11,4 @@
  * limitations under the License.
  */
 
-export * from './locator';
-export * from './utils';
-export * from './constants';
+export const AWS_SDK_CUSTOM_USER_AGENT = 'backstage-plugins-for-aws';

--- a/plugins/core/common/src/locator/aws-config-locator.ts
+++ b/plugins/core/common/src/locator/aws-config-locator.ts
@@ -18,7 +18,10 @@ import {
   paginateSelectResourceConfig,
 } from '@aws-sdk/client-config-service';
 import { Logger } from 'winston';
-import { AwsResourceLocator } from '@aws/aws-core-plugin-for-backstage-common';
+import {
+  AWS_SDK_CUSTOM_USER_AGENT,
+  AwsResourceLocator,
+} from '@aws/aws-core-plugin-for-backstage-common';
 import { AwsCredentialIdentityProvider, Paginator } from '@aws-sdk/types';
 import { Config } from '@backstage/config';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
@@ -66,7 +69,7 @@ export class AwsConfigResourceLocator implements AwsResourceLocator {
 
     const client = new ConfigServiceClient({
       region: region,
-      customUserAgent: 'aws-config-plugin-for-backstage',
+      customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
       credentialDefaultProvider: () => credentialProvider,
     });
 

--- a/plugins/core/common/src/locator/resource-explorer-locator.ts
+++ b/plugins/core/common/src/locator/resource-explorer-locator.ts
@@ -16,7 +16,10 @@ import {
   SearchCommand,
 } from '@aws-sdk/client-resource-explorer-2';
 import { Logger } from 'winston';
-import { AwsResourceLocator } from '@aws/aws-core-plugin-for-backstage-common';
+import {
+  AWS_SDK_CUSTOM_USER_AGENT,
+  AwsResourceLocator,
+} from '@aws/aws-core-plugin-for-backstage-common';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { Config } from '@backstage/config';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
@@ -62,7 +65,7 @@ export class AwsResourceExplorerLocator implements AwsResourceLocator {
 
     const client = new ResourceExplorer2Client({
       region: region,
-      customUserAgent: 'aws-resourceexplorer-plugin-for-backstage',
+      customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
       credentialDefaultProvider: () => credentialProvider,
     });
 

--- a/plugins/core/scaffolder-actions/package.json
+++ b/plugins/core/scaffolder-actions/package.json
@@ -33,6 +33,7 @@
     "@aws-sdk/client-eventbridge": "^3.511.0",
     "@aws-sdk/client-s3": "^3.511.0",
     "@aws-sdk/types": "^3.511.0",
+    "@aws/aws-core-plugin-for-backstage-common": "workspace:^",
     "@backstage/backend-common": "^0.21.6",
     "@backstage/backend-plugin-api": "^0.6.16",
     "@backstage/errors": "^1.2.4",

--- a/plugins/core/scaffolder-actions/src/actions/cloudcontrol/create.ts
+++ b/plugins/core/scaffolder-actions/src/actions/cloudcontrol/create.ts
@@ -21,6 +21,7 @@ import {
 import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { z } from 'zod';
+import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 
 export const createAwsCloudControlCreateAction = (options: {
   credsManager: AwsCredentialsManager;
@@ -122,7 +123,7 @@ export const createAwsCloudControlCreateAction = (options: {
 
       const client = new CloudControlClient({
         region,
-        customUserAgent: 'aws-scaffolder-plugin-for-backstage',
+        customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
         credentialDefaultProvider: () => credentialProvider,
       });
       const response = await client.send(

--- a/plugins/core/scaffolder-actions/src/actions/codecommit/publish.ts
+++ b/plugins/core/scaffolder-actions/src/actions/codecommit/publish.ts
@@ -23,6 +23,7 @@ import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
+import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 
 export const createAwsCodeCommitPublishAction = (options: {
   credsManager: AwsCredentialsManager;
@@ -124,7 +125,7 @@ export const createAwsCodeCommitPublishAction = (options: {
 
       const client = new CodeCommitClient({
         region,
-        customUserAgent: 'aws-scaffolder-plugin-for-backstage',
+        customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
         credentialDefaultProvider: () => credentialProvider,
       });
       const response = await client.send(

--- a/plugins/core/scaffolder-actions/src/actions/eventbridge/eventbridge.ts
+++ b/plugins/core/scaffolder-actions/src/actions/eventbridge/eventbridge.ts
@@ -19,6 +19,7 @@ import {
 import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { z } from 'zod';
+import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 
 export const createAwsEventBridgeEventAction = (options: {
   credsManager: AwsCredentialsManager;
@@ -75,7 +76,7 @@ export const createAwsEventBridgeEventAction = (options: {
 
       const client = new EventBridgeClient({
         region,
-        customUserAgent: 'aws-scaffolder-plugin-for-backstage',
+        customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
         credentialDefaultProvider: () => credentialProvider,
       });
       await client.send(

--- a/plugins/core/scaffolder-actions/src/actions/s3/cp.ts
+++ b/plugins/core/scaffolder-actions/src/actions/s3/cp.ts
@@ -21,6 +21,7 @@ import fs from 'fs-extra';
 import { z } from 'zod';
 import { resolveSafeChildPath } from '@backstage/backend-common';
 import { glob } from 'glob';
+import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 
 export const createAwsS3CpAction = (options: {
   credsManager: AwsCredentialsManager;
@@ -77,7 +78,7 @@ export const createAwsS3CpAction = (options: {
 
       const client = new S3Client({
         region,
-        customUserAgent: 'aws-scaffolder-plugin-for-backstage',
+        customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
         credentialDefaultProvider: () => credentialProvider,
       });
 

--- a/plugins/ecs/backend/src/service/DefaultAmazonEcsService.ts
+++ b/plugins/ecs/backend/src/service/DefaultAmazonEcsService.ts
@@ -25,6 +25,7 @@ import {
   AwsResourceLocatorFactory,
   AwsResourceLocator,
   getOneOfEntityAnnotations,
+  AWS_SDK_CUSTOM_USER_AGENT,
 } from '@aws/aws-core-plugin-for-backstage-common';
 import {
   AWS_ECS_SERVICE_ARN_ANNOTATION,
@@ -171,7 +172,7 @@ export class DefaultAmazonEcsService implements AmazonECSService {
 
     const client = new ECSClient({
       region: region,
-      customUserAgent: 'aws-ecs-plugin-for-backstage',
+      customUserAgent: AWS_SDK_CUSTOM_USER_AGENT,
       credentialDefaultProvider: () => credentialProvider,
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2107,6 +2107,7 @@ __metadata:
     "@aws-sdk/client-eventbridge": "npm:^3.511.0"
     "@aws-sdk/client-s3": "npm:^3.511.0"
     "@aws-sdk/types": "npm:^3.511.0"
+    "@aws/aws-core-plugin-for-backstage-common": "workspace:^"
     "@backstage/backend-common": "npm:^0.21.6"
     "@backstage/backend-plugin-api": "npm:^0.6.16"
     "@backstage/backend-test-utils": "npm:^0.3.6"


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The AWS SDK clients created are already adding custom user agent headers, but these headers are unique to each plugin. This makes it more difficult to create consistent filters to catch all AWS API calls when running Backstage in order to trace calls through services like CloudTrail.

### Description of changes

Adds a string constant for a consistent user agent header and uses this throughout the various packages.

### Description of how you validated changes

Existing unit tests

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
