### PR TITLE
style: move the title to the inside of the card for Amazon ECS Services and AWS CodePipeline

### DIFF
--- a/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.tsx
+++ b/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.tsx
@@ -22,7 +22,6 @@ import {
   Table,
   SubvalueCell,
   ResponseErrorPanel,
-  ContentHeader,
 } from '@backstage/core-components';
 import { PipelineExecutionSummary } from '@aws-sdk/client-codepipeline';
 import { PipelineStageStatus } from '../PipelineStageStatus';
@@ -140,6 +139,7 @@ const CodePipelineExecutionsTable = ({
     <Table
       data={response.pipelineExecutions}
       columns={generatedColumns(response.pipelineName, response.pipelineArn)}
+      title="AWS CodePipeline"
     />
   );
 };
@@ -204,17 +204,6 @@ const CodePipelineExecutionsContent = ({
   return <CodePipelineMultipleExecutionsContent response={response} />;
 };
 
-const CodePipelineExecutionsWrapper = ({
-  response,
-}: CodePipelineExecutionsContentProps) => {
-  return (
-    <>
-      <ContentHeader title="AWS CodePipeline" />
-      <CodePipelineExecutionsContent response={response} />
-    </>
-  );
-};
-
 type CodePipelineExecutionsProps = {
   entity: Entity;
 };
@@ -232,5 +221,5 @@ export const CodePipelineExecutions = ({
     return <LinearProgress />;
   }
 
-  return <CodePipelineExecutionsWrapper response={response!} />;
+  return <CodePipelineExecutionsContent response={response!} />;
 };

--- a/plugins/ecs/frontend/src/components/EcsServices/EcsServices.tsx
+++ b/plugins/ecs/frontend/src/components/EcsServices/EcsServices.tsx
@@ -18,10 +18,11 @@ import {
   AccordionSummary,
   Grid,
   LinearProgress,
+  Paper,
   Typography,
 } from '@material-ui/core';
 import {
-  ContentHeader,
+  InfoCard,
   ResponseErrorPanel,
   StatusAborted,
   StatusError,
@@ -303,7 +304,7 @@ const EcsServicesContent = ({ response }: EcsServicesContentProps) => {
     <>
       {response.clusters.map(e => {
         return (
-          <Accordion key="{e}">
+          <Accordion key="{e}" elevation={0}>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <ClusterSummary cluster={e} />
             </AccordionSummary>
@@ -312,7 +313,7 @@ const EcsServicesContent = ({ response }: EcsServicesContentProps) => {
                 <Grid item>
                   {e.services.map(s => {
                     return (
-                      <Accordion key="{s}">
+                      <Accordion key="{s}" elevation={0}>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                           <ServiceSummary service={s.service} />
                         </AccordionSummary>
@@ -324,9 +325,15 @@ const EcsServicesContent = ({ response }: EcsServicesContentProps) => {
                                   paging: true,
                                   search: false,
                                   emptyRowsWhenPaging: false,
+                                  toolbar: false,
                                 }}
                                 data={s.tasks}
                                 columns={columns}
+                                components={{
+                                  Container: props => (
+                                    <Paper {...props} elevation={0} />
+                                  ),
+                                }}
                               />
                             </Grid>
                           </Grid>
@@ -349,9 +356,10 @@ const EcsServicesWrapper = ({ response }: EcsServicesContentProps) => {
 
   return (
     <>
-      <ContentHeader title="Amazon ECS Services" />
       {hasClusters ? (
-        <EcsServicesContent response={response} />
+        <InfoCard title="Amazon ECS Services">
+          <EcsServicesContent response={response} />
+        </InfoCard>
       ) : (
         <MissingResources />
       )}

--- a/plugins/ecs/frontend/src/components/EcsServices/EcsServices.tsx
+++ b/plugins/ecs/frontend/src/components/EcsServices/EcsServices.tsx
@@ -323,7 +323,6 @@ const EcsServicesContent = ({ response }: EcsServicesContentProps) => {
                               <Table
                                 options={{
                                   paging: true,
-                                  search: false,
                                   emptyRowsWhenPaging: false,
                                   toolbar: false,
                                 }}


### PR DESCRIPTION
### Reason for this change

The placement of the title of the card for Amazon ECS Services and AWS CodePipeline was inconsistent with other Backstage components.

### Description of changes

I move the title to the inside of the card for Amazon ECS Services and AWS CodePipeline. I also removed some box shadow and spacing caused due to the unused toolbar of the table inside the AWS ECS Services card to make it look less like a mix of individual components.

### Description of how you validated changes

I tested the changes locally and took screenshots:

<img width="1256" alt="Scherm­afbeelding 2024-05-02 om 10 51 14" src="https://github.com/awslabs/backstage-plugins-for-aws/assets/24613245/3a4a47ce-7725-45f7-b04f-f4da79dfd8c4">
<img width="1251" alt="Scherm­afbeelding 2024-05-02 om 10 53 33" src="https://github.com/awslabs/backstage-plugins-for-aws/assets/24613245/71da31ba-5949-4841-bc8e-2f1b9c68b02c">

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
