### PR TITLE
feat: Make CodePipeline and CodeBuild annotations backwards-compatible

### DIFF
--- a/plugins/codebuild/backend/src/service/DefaultAwsCodeBuildService.test.ts
+++ b/plugins/codebuild/backend/src/service/DefaultAwsCodeBuildService.test.ts
@@ -31,6 +31,7 @@ import {
 } from '@aws-sdk/client-codebuild';
 import {
   AWS_CODEBUILD_ARN_ANNOTATION,
+  AWS_CODEBUILD_ARN_ANNOTATION_LEGACY,
   AWS_CODEBUILD_TAGS_ANNOTATION,
   mockCodeBuildProject,
   mockCodeBuildProjectBuild,
@@ -222,6 +223,72 @@ describe('DefaultAwsCodeBuildService', () => {
           metadata: {
             annotations: {
               [AWS_CODEBUILD_ARN_ANNOTATION]:
+                'arn:aws:codebuild:us-west-2:1234567890:project/project1',
+            },
+          },
+        },
+      );
+
+      const response = await service.getProjectsByEntity({ entityRef });
+
+      expect(response.projects.length).toBe(1);
+
+      await expect(response).toMatchObject({
+        projects: [
+          {
+            project: project1,
+            builds: project1Builds.slice(0, 5),
+          },
+        ],
+      });
+
+      expect(mockResourceLocator.getResourceArns).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('by arn (legacy)', () => {
+    it('returns ok', async () => {
+      const { project: project1, projectBuilds: project1Builds } =
+        setupCodeBuildProjectMock('project1', 5);
+
+      const service = await configureProvider(
+        {},
+        {
+          metadata: {
+            annotations: {
+              [AWS_CODEBUILD_ARN_ANNOTATION_LEGACY]:
+                'arn:aws:codebuild:us-west-2:1234567890:project/project1',
+            },
+          },
+        },
+      );
+
+      const response = await service.getProjectsByEntity({ entityRef });
+
+      expect(response.projects.length).toBe(1);
+
+      await expect(response).toMatchObject({
+        projects: [
+          {
+            project: project1,
+            builds: project1Builds,
+          },
+        ],
+      });
+
+      expect(mockResourceLocator.getResourceArns).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns max 5 builds', async () => {
+      const { project: project1, projectBuilds: project1Builds } =
+        setupCodeBuildProjectMock('project1', 10);
+
+      const service = await configureProvider(
+        {},
+        {
+          metadata: {
+            annotations: {
+              [AWS_CODEBUILD_ARN_ANNOTATION_LEGACY]:
                 'arn:aws:codebuild:us-west-2:1234567890:project/project1',
             },
           },

--- a/plugins/codebuild/backend/src/service/DefaultAwsCodeBuildService.ts
+++ b/plugins/codebuild/backend/src/service/DefaultAwsCodeBuildService.ts
@@ -37,6 +37,7 @@ import {
 } from '@aws-sdk/client-codebuild';
 import {
   AWS_CODEBUILD_ARN_ANNOTATION,
+  AWS_CODEBUILD_ARN_ANNOTATION_LEGACY,
   AWS_CODEBUILD_TAGS_ANNOTATION,
   ProjectsResponse,
 } from '@aws/aws-codebuild-plugin-for-backstage-common';
@@ -164,6 +165,7 @@ export class DefaultAwsCodeBuildService implements AwsCodeBuildService {
     const annotation = getOneOfEntityAnnotations(entity, [
       AWS_CODEBUILD_ARN_ANNOTATION,
       AWS_CODEBUILD_TAGS_ANNOTATION,
+      AWS_CODEBUILD_ARN_ANNOTATION_LEGACY,
     ]);
 
     if (!annotation) {

--- a/plugins/codebuild/common/src/mocks/index.ts
+++ b/plugins/codebuild/common/src/mocks/index.ts
@@ -15,6 +15,7 @@ import { Build, Project } from '@aws-sdk/client-codebuild';
 import { Entity } from '@backstage/catalog-model';
 import {
   AWS_CODEBUILD_ARN_ANNOTATION,
+  AWS_CODEBUILD_ARN_ANNOTATION_LEGACY,
   AWS_CODEBUILD_TAGS_ANNOTATION,
 } from '../types';
 
@@ -285,6 +286,24 @@ export const mockEntityWithArn: Entity = {
     description: 'backstage.io',
     annotations: {
       [AWS_CODEBUILD_ARN_ANNOTATION]:
+        'arn:aws:codebuild:us-west-2:1234567890:project/mock',
+    },
+  },
+  spec: {
+    lifecycle: 'production',
+    type: 'service',
+    owner: 'user:guest',
+  },
+};
+
+export const mockEntityWithArnLegacy: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'backstage',
+    description: 'backstage.io',
+    annotations: {
+      [AWS_CODEBUILD_ARN_ANNOTATION_LEGACY]:
         'arn:aws:codebuild:us-west-2:1234567890:project/mock',
     },
   },

--- a/plugins/codebuild/common/src/types.ts
+++ b/plugins/codebuild/common/src/types.ts
@@ -17,6 +17,8 @@ export const AWS_CODEBUILD_ARN_ANNOTATION =
   'aws.amazon.com/aws-codebuild-project-arn';
 export const AWS_CODEBUILD_TAGS_ANNOTATION =
   'aws.amazon.com/aws-codebuild-project-tags';
+export const AWS_CODEBUILD_ARN_ANNOTATION_LEGACY =
+  'aws.amazon.com/aws-codebuild-project';
 
 export interface ProjectResponse {
   project: Project;

--- a/plugins/codebuild/frontend/src/plugin.ts
+++ b/plugins/codebuild/frontend/src/plugin.ts
@@ -13,6 +13,7 @@
 
 import {
   AWS_CODEBUILD_ARN_ANNOTATION,
+  AWS_CODEBUILD_ARN_ANNOTATION_LEGACY,
   AWS_CODEBUILD_TAGS_ANNOTATION,
 } from '@aws/aws-codebuild-plugin-for-backstage-common';
 import { getOneOfEntityAnnotations } from '@aws/aws-core-plugin-for-backstage-common';
@@ -31,6 +32,7 @@ export const isAwsCodeBuildAvailable = (entity: Entity) =>
   getOneOfEntityAnnotations(entity, [
     AWS_CODEBUILD_ARN_ANNOTATION,
     AWS_CODEBUILD_TAGS_ANNOTATION,
+    AWS_CODEBUILD_ARN_ANNOTATION_LEGACY,
   ]) !== undefined;
 
 export const awsCodeBuildPlugin = createPlugin({

--- a/plugins/codepipeline/backend/src/service/DefaultAwsCodePipelineService.ts
+++ b/plugins/codepipeline/backend/src/service/DefaultAwsCodePipelineService.ts
@@ -36,6 +36,7 @@ import {
 } from '@aws-sdk/client-codepipeline';
 import {
   AWS_CODEPIPELINE_ARN_ANNOTATION,
+  AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY,
   AWS_CODEPIPELINE_TAGS_ANNOTATION,
   PipelineExecutionsResponse,
   PipelineStateResponse,
@@ -211,6 +212,7 @@ export class DefaultAwsCodePipelineService implements AwsCodePipelineService {
     const annotation = getOneOfEntityAnnotations(entity, [
       AWS_CODEPIPELINE_ARN_ANNOTATION,
       AWS_CODEPIPELINE_TAGS_ANNOTATION,
+      AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY,
     ]);
 
     if (!annotation) {

--- a/plugins/codepipeline/common/src/mocks/index.ts
+++ b/plugins/codepipeline/common/src/mocks/index.ts
@@ -20,6 +20,7 @@ import {
 import { Entity } from '@backstage/catalog-model';
 import {
   AWS_CODEPIPELINE_ARN_ANNOTATION,
+  AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY,
   AWS_CODEPIPELINE_TAGS_ANNOTATION,
 } from '../types';
 
@@ -171,6 +172,24 @@ export const mockEntityWithArn: Entity = {
     description: 'backstage.io',
     annotations: {
       [AWS_CODEPIPELINE_ARN_ANNOTATION]:
+        'arn:aws:codepipeline:us-west-2:1234567890:pipeline1',
+    },
+  },
+  spec: {
+    lifecycle: 'production',
+    type: 'service',
+    owner: 'user:guest',
+  },
+};
+
+export const mockEntityWithArnLegacy: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'backstage',
+    description: 'backstage.io',
+    annotations: {
+      [AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY]:
         'arn:aws:codepipeline:us-west-2:1234567890:pipeline1',
     },
   },

--- a/plugins/codepipeline/common/src/types.ts
+++ b/plugins/codepipeline/common/src/types.ts
@@ -20,6 +20,8 @@ export const AWS_CODEPIPELINE_ARN_ANNOTATION =
   'aws.amazon.com/aws-codepipeline-arn';
 export const AWS_CODEPIPELINE_TAGS_ANNOTATION =
   'aws.amazon.com/aws-codepipeline-tags';
+export const AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY =
+  'aws.amazon.com/aws-codepipeline';
 
 export interface PipelineExecutions {
   pipelineExecutions: Array<PipelineExecutionSummary>;

--- a/plugins/codepipeline/frontend/src/components/Router.tsx
+++ b/plugins/codepipeline/frontend/src/components/Router.tsx
@@ -21,6 +21,7 @@ import {
 import { getOneOfEntityAnnotations } from '@aws/aws-core-plugin-for-backstage-common';
 import {
   AWS_CODEPIPELINE_ARN_ANNOTATION,
+  AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY,
   AWS_CODEPIPELINE_TAGS_ANNOTATION,
 } from '@aws/aws-codepipeline-plugin-for-backstage-common';
 import { CodePipelineExecutions } from './CodePipelineExecutions';
@@ -29,6 +30,7 @@ export const isAwsCodePipelineAvailable = (entity: Entity) =>
   getOneOfEntityAnnotations(entity, [
     AWS_CODEPIPELINE_ARN_ANNOTATION,
     AWS_CODEPIPELINE_TAGS_ANNOTATION,
+    AWS_CODEPIPELINE_ARN_ANNOTATION_LEGACY,
   ]) !== undefined;
 
 export const Router = () => {


### PR DESCRIPTION
### Issue #

Closes #7 

### Reason for this change

Some people already have a catalog that utilizes the annotations of the now deprecated `@aws/aws-codeservices-backend-plugin-for-backstage`. Updating to this version would require updating the `catalog-info.yaml` file of every entity, which can be a big undertaking depending on the amount of entities they have.

### Description of changes

I added support for the previous annotations for CodePipeline and CodeBuild, while not recommending to use them anymore by leaving them out of the MissingAnnotationEmptyState.

### Description of how you validated changes

I tested these changes locally and extended the current unit tests where applicable.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
