### PR TITLE
fix: CodePipeline execution URLs

### DIFF
--- a/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.tsx
+++ b/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.tsx
@@ -138,7 +138,7 @@ const CodePipelineExecutionsTable = ({
   return (
     <Table
       data={response.pipelineExecutions}
-      columns={generatedColumns(response.pipelineName, response.pipelineArn)}
+      columns={generatedColumns(response.pipelineName, response.pipelineRegion)}
       title="AWS CodePipeline"
     />
   );


### PR DESCRIPTION
### Reason for this change

I noticed that the execution URLs of the AWS CodePipeline plugin didn't work.

### Description of changes

I passed the region to the generatedColumns function instead of the ARN.

### Description of how you validated changes

I inspected and tried the link and it works now.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
