### PR TITLE
fix: Handle case where no ECS tasks are returned

### DIFF
--- a/plugins/ecs/backend/src/service/DefaultAmazonEcsService.ts
+++ b/plugins/ecs/backend/src/service/DefaultAmazonEcsService.ts
@@ -18,6 +18,7 @@ import {
   DescribeClustersCommand,
   ListTasksCommand,
   DescribeTasksCommand,
+  Task,
 } from '@aws-sdk/client-ecs';
 import { parse } from '@aws-sdk/util-arn-parser';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -205,16 +206,22 @@ export class DefaultAmazonEcsService implements AmazonECSService {
             }),
           );
 
-          const describeTasksResp = await client.send(
-            new DescribeTasksCommand({
-              cluster,
-              tasks: listTasksResp.taskArns,
-            }),
-          );
+          let tasks: Task[] = [];
+
+          if (listTasksResp.taskArns?.length) {
+            const describeTasksResp = await client.send(
+              new DescribeTasksCommand({
+                cluster,
+                tasks: listTasksResp.taskArns,
+              }),
+            );
+
+            tasks = describeTasksResp.tasks || [];
+          }
 
           serviceResponseObjects.push({
             service: serviceResp,
-            tasks: describeTasksResp.tasks!,
+            tasks,
           });
         }
       }

--- a/plugins/ecs/frontend/src/components/EcsServices/EcsServices.tsx
+++ b/plugins/ecs/frontend/src/components/EcsServices/EcsServices.tsx
@@ -230,7 +230,11 @@ const ClusterSummary = ({ cluster }: { cluster: ClusterResponse }) => {
         spacing={0}
       >
         <Grid item>
-          <StatusOK>{runningTasks} running tasks</StatusOK>
+          {runningTasks > 0 ? (
+            <StatusOK>{runningTasks} running tasks</StatusOK>
+          ) : (
+            <StatusOK>No running tasks</StatusOK>
+          )}
         </Grid>
         <Grid item>
           {pendingTasks > 0 ? (
@@ -279,7 +283,11 @@ const ServiceSummary = ({ service }: { service: Service }) => {
         spacing={0}
       >
         <Grid item>
-          <StatusOK>{service.runningCount} running tasks</StatusOK>
+          {service.runningCount! > 0 ? (
+            <StatusOK>{service.runningCount} running tasks</StatusOK>
+          ) : (
+            <StatusOK>No running tasks</StatusOK>
+          )}
         </Grid>
         <Grid item>
           {service.pendingCount! > 0 ? (


### PR DESCRIPTION
### Issue # (if applicable)

Related to #140  

### Reason for this change

When the ECS API returns no tasks it should not display an error, just an empty list

### Description of changes

Altered code path to gracefully handle no ECS tasks being returned

### Description of how you validated changes

Added unit test for this scenario

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
