### PR TITLE
feat: Use serviceRefs for backend services

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -65,7 +65,8 @@ techdocs:
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   providers:
-    guest: {}
+    guest:
+      userEntityRef: user:default/guest
 
 scaffolder:
 # see https://backstage.io/docs/features/software-templates/configuration for software template options

--- a/examples/entities.yaml
+++ b/examples/entities.yaml
@@ -16,6 +16,7 @@ metadata:
     aws.amazon.com/aws-codepipeline-tags: component=example-website
     aws.amazon.com/aws-codebuild-project-tags: component=example-website
     aws.amazon.com/amazon-ecs-service-tags: component=example-website
+    aws.amazon.com/cost-insights-tags: component=example-website
 spec:
   type: website
   lifecycle: experimental

--- a/examples/org.yaml
+++ b/examples/org.yaml
@@ -4,6 +4,7 @@ apiVersion: backstage.io/v1alpha1
 kind: User
 metadata:
   name: guest
+  namespace: default
 spec:
   memberOf: [guests]
 ---
@@ -12,6 +13,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
   name: guests
+  namespace: default
 spec:
   type: team
   children: []

--- a/plugins/codebuild/backend/src/plugin.ts
+++ b/plugins/codebuild/backend/src/plugin.ts
@@ -11,14 +11,13 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   createBackendPlugin,
   coreServices,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
-import { DefaultAwsCodeBuildService } from './service/DefaultAwsCodeBuildService';
+import { awsCodeBuildServiceRef } from './service/DefaultAwsCodeBuildService';
 
 export const awsCodebuildPlugin = createBackendPlugin({
   pluginId: 'aws-codebuild',
@@ -32,31 +31,19 @@ export const awsCodebuildPlugin = createBackendPlugin({
         auth: coreServices.auth,
         discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
+        awsCodeBuildApi: awsCodeBuildServiceRef,
       },
       async init({
         logger,
         httpRouter,
-        config,
-        catalogApi,
         auth,
         httpAuth,
         discovery,
+        awsCodeBuildApi,
       }) {
-        const winstonLogger = loggerToWinstonLogger(logger);
-
-        const awsCodeBuildApi = await DefaultAwsCodeBuildService.fromConfig(
-          config,
-          {
-            catalogApi,
-            auth,
-            httpAuth,
-            discovery,
-            logger: winstonLogger,
-          },
-        );
         httpRouter.use(
           await createRouter({
-            logger: winstonLogger,
+            logger,
             awsCodeBuildApi,
             discovery,
             auth,

--- a/plugins/codebuild/backend/src/service/router.ts
+++ b/plugins/codebuild/backend/src/service/router.ts
@@ -17,16 +17,16 @@ import {
 } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
-import { Logger } from 'winston';
 import { AwsCodeBuildService } from './types';
 import {
   AuthService,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: LoggerService;
   awsCodeBuildApi: AwsCodeBuildService;
   discovery: DiscoveryService;
   auth?: AuthService;

--- a/plugins/codepipeline/backend/src/plugin.ts
+++ b/plugins/codepipeline/backend/src/plugin.ts
@@ -11,14 +11,13 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   createBackendPlugin,
   coreServices,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
-import { DefaultAwsCodePipelineService } from './service/DefaultAwsCodePipelineService';
+import { awsCodePipelineServiceRef } from './service/DefaultAwsCodePipelineService';
 
 export const awsCodePiplinePlugin = createBackendPlugin({
   pluginId: 'aws-codepipeline',
@@ -32,29 +31,19 @@ export const awsCodePiplinePlugin = createBackendPlugin({
         auth: coreServices.auth,
         discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
+        awsCodePipelineApi: awsCodePipelineServiceRef,
       },
       async init({
         logger,
         httpRouter,
-        config,
-        catalogApi,
         auth,
         httpAuth,
         discovery,
+        awsCodePipelineApi,
       }) {
-        const winstonLogger = loggerToWinstonLogger(logger);
-
-        const awsCodePipelineApi =
-          await DefaultAwsCodePipelineService.fromConfig(config, {
-            catalogApi,
-            auth,
-            httpAuth,
-            discovery,
-            logger: winstonLogger,
-          });
         httpRouter.use(
           await createRouter({
-            logger: winstonLogger,
+            logger,
             awsCodePipelineApi,
             discovery,
             auth,

--- a/plugins/codepipeline/backend/src/service/DefaultAwsCodePipelineService.ts
+++ b/plugins/codepipeline/backend/src/service/DefaultAwsCodePipelineService.ts
@@ -11,7 +11,6 @@
  * limitations under the License.
  */
 
-import { Logger } from 'winston';
 import { parse } from '@aws-sdk/util-arn-parser';
 import { CatalogApi } from '@backstage/catalog-client';
 import {
@@ -46,16 +45,21 @@ import {
 import {
   AuthService,
   BackstageCredentials,
+  coreServices,
+  createServiceFactory,
+  createServiceRef,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 import { createLegacyAuthAdapters } from '@backstage/backend-common';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 
 const DEFAULT_EXECUTIONS_LIMIT = 100;
 
 export class DefaultAwsCodePipelineService implements AwsCodePipelineService {
   public constructor(
-    private readonly logger: Logger,
+    private readonly logger: LoggerService,
     private readonly auth: AuthService,
     private readonly catalogApi: CatalogApi,
     private readonly resourceLocator: AwsResourceLocator,
@@ -69,7 +73,7 @@ export class DefaultAwsCodePipelineService implements AwsCodePipelineService {
       discovery: DiscoveryService;
       auth?: AuthService;
       httpAuth?: HttpAuthService;
-      logger: Logger;
+      logger: LoggerService;
       resourceLocator?: AwsResourceLocator;
     },
   ) {
@@ -250,3 +254,38 @@ export class DefaultAwsCodePipelineService implements AwsCodePipelineService {
     });
   }
 }
+
+export const awsCodePipelineServiceRef =
+  createServiceRef<AwsCodePipelineService>({
+    id: 'aws-codepipeline.api',
+    defaultFactory: async service =>
+      createServiceFactory({
+        service,
+        deps: {
+          logger: coreServices.logger,
+          config: coreServices.rootConfig,
+          catalogApi: catalogServiceRef,
+          auth: coreServices.auth,
+          discovery: coreServices.discovery,
+          httpAuth: coreServices.httpAuth,
+        },
+        async factory({
+          logger,
+          config,
+          catalogApi,
+          auth,
+          httpAuth,
+          discovery,
+        }) {
+          const impl = await DefaultAwsCodePipelineService.fromConfig(config, {
+            catalogApi,
+            auth,
+            httpAuth,
+            discovery,
+            logger,
+          });
+
+          return impl;
+        },
+      }),
+  });

--- a/plugins/codepipeline/backend/src/service/router.ts
+++ b/plugins/codepipeline/backend/src/service/router.ts
@@ -17,16 +17,16 @@ import {
 } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
-import { Logger } from 'winston';
 import { AwsCodePipelineService } from './types';
 import {
   AuthService,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: LoggerService;
   awsCodePipelineApi: AwsCodePipelineService;
   discovery: DiscoveryService;
   auth?: AuthService;

--- a/plugins/core/node/package.json
+++ b/plugins/core/node/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/client-resource-groups-tagging-api": "^3.511.0",
     "@aws-sdk/types": "^3.511.0",
     "@aws/aws-core-plugin-for-backstage-common": "workspace:^",
+    "@backstage/backend-plugin-api": "^0.8.1",
     "@backstage/config": "^1.2.0",
     "@backstage/integration-aws-node": "^0.1.12",
     "winston": "^3.11.0"

--- a/plugins/core/node/src/locator/aws-config-locator.ts
+++ b/plugins/core/node/src/locator/aws-config-locator.ts
@@ -18,19 +18,19 @@ import {
   paginateSelectAggregateResourceConfig,
   paginateSelectResourceConfig,
 } from '@aws-sdk/client-config-service';
-import { Logger } from 'winston';
 import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 import { AwsCredentialIdentityProvider, Paginator } from '@aws-sdk/types';
 import { Config } from '@backstage/config';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { convertResourceTypeString, parseResourceLocatorTags } from './utils';
 import { AwsResourceLocator } from '.';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class AwsConfigResourceLocator implements AwsResourceLocator {
   static readonly AWS_CONFIG_QUERY_TEMPLATE = 'SELECT arn';
 
   public constructor(
-    private readonly logger: Logger,
+    private readonly logger: LoggerService,
     private readonly client: ConfigServiceClient,
     private readonly aggregatorName: string | undefined,
   ) {}
@@ -38,7 +38,7 @@ export class AwsConfigResourceLocator implements AwsResourceLocator {
   static async fromConfig(
     config: Config,
     options: {
-      logger: Logger;
+      logger: LoggerService;
     },
   ) {
     let region: string | undefined;

--- a/plugins/core/node/src/locator/resource-explorer-locator.ts
+++ b/plugins/core/node/src/locator/resource-explorer-locator.ts
@@ -15,17 +15,17 @@ import {
   ResourceExplorer2Client,
   SearchCommand,
 } from '@aws-sdk/client-resource-explorer-2';
-import { Logger } from 'winston';
 import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { Config } from '@backstage/config';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { convertResourceTypeString, parseResourceLocatorTags } from './utils';
 import { AwsResourceLocator } from '.';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class AwsResourceExplorerLocator implements AwsResourceLocator {
   public constructor(
-    private readonly logger: Logger,
+    private readonly logger: LoggerService,
     private readonly client: ResourceExplorer2Client,
     private readonly viewArn: string | undefined,
   ) {}
@@ -33,7 +33,7 @@ export class AwsResourceExplorerLocator implements AwsResourceLocator {
   static async fromConfig(
     config: Config,
     options: {
-      logger: Logger;
+      logger: LoggerService;
     },
   ) {
     let region: string | undefined;

--- a/plugins/core/node/src/locator/resource-locator-factory.ts
+++ b/plugins/core/node/src/locator/resource-locator-factory.ts
@@ -12,15 +12,15 @@
  */
 
 import { Config } from '@backstage/config';
-import { Logger } from 'winston';
 import { AwsResourceLocator, AwsResourceTaggingApiLocator } from '.';
 import { AwsResourceExplorerLocator } from './resource-explorer-locator';
 import { AwsConfigResourceLocator } from './aws-config-locator';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class AwsResourceLocatorFactory {
   static async fromConfig(
     config: Config,
-    logger: Logger,
+    logger: LoggerService,
   ): Promise<AwsResourceLocator> {
     const conf = config.getOptionalConfig('aws.locator');
 

--- a/plugins/core/node/src/locator/resource-tagging-api-instance.ts
+++ b/plugins/core/node/src/locator/resource-tagging-api-instance.ts
@@ -15,15 +15,15 @@ import {
   GetResourcesCommand,
   ResourceGroupsTaggingAPIClient,
 } from '@aws-sdk/client-resource-groups-tagging-api';
-import { Logger } from 'winston';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { convertResourceTypeString, parseResourceLocatorTags } from './utils';
 import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class AwsResourceTaggingApiLocatorInstance {
   public constructor(
-    private readonly logger: Logger,
+    private readonly logger: LoggerService,
     private readonly client: ResourceGroupsTaggingAPIClient,
   ) {}
 
@@ -31,7 +31,7 @@ export class AwsResourceTaggingApiLocatorInstance {
     credsManager: DefaultAwsCredentialsManager;
     accountId: string | undefined;
     region: string | undefined;
-    logger: Logger;
+    logger: LoggerService;
   }): Promise<AwsResourceTaggingApiLocatorInstance> {
     let credentialProvider: AwsCredentialIdentityProvider;
 

--- a/plugins/core/node/src/locator/resource-tagging-api-locator.ts
+++ b/plugins/core/node/src/locator/resource-tagging-api-locator.ts
@@ -11,11 +11,11 @@
  * limitations under the License.
  */
 
-import { Logger } from 'winston';
 import { AwsResourceLocator } from '.';
 import { Config } from '@backstage/config';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsResourceTaggingApiLocatorInstance } from './resource-tagging-api-instance';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class AwsResourceTaggingApiLocator implements AwsResourceLocator {
   public constructor(
@@ -25,7 +25,7 @@ export class AwsResourceTaggingApiLocator implements AwsResourceLocator {
   static async fromConfig(
     config: Config,
     options: {
-      logger: Logger;
+      logger: LoggerService;
     },
   ) {
     let regions: (string | undefined)[] = [undefined];

--- a/plugins/cost-insights/backend/src/cache/CostInsightsCache.ts
+++ b/plugins/cost-insights/backend/src/cache/CostInsightsCache.ts
@@ -12,15 +12,14 @@
  */
 
 import { assertError } from '@backstage/errors';
-import { Logger } from 'winston';
-import { CacheService } from '@backstage/backend-plugin-api';
+import { CacheService, LoggerService } from '@backstage/backend-plugin-api';
 import { CostInsightsAwsConfig } from '../config';
 
 const KEY_PREFIX = 'cost-insights:';
 
 export class CostInsightsCache {
   protected readonly cache: CacheService;
-  protected readonly logger: Logger;
+  protected readonly logger: LoggerService;
   protected readonly readTimeout: number;
 
   private constructor({
@@ -29,7 +28,7 @@ export class CostInsightsCache {
     readTimeout,
   }: {
     cache: CacheService;
-    logger: Logger;
+    logger: LoggerService;
     readTimeout: number;
   }) {
     this.cache = cache;
@@ -39,7 +38,7 @@ export class CostInsightsCache {
 
   static fromConfig(
     config: CostInsightsAwsConfig,
-    { cache, logger }: { cache: CacheService; logger: Logger },
+    { cache, logger }: { cache: CacheService; logger: LoggerService },
   ) {
     return new CostInsightsCache({
       cache: cache.withOptions({ defaultTtl: config.cache.defaultTtl }),
@@ -65,7 +64,7 @@ export class CostInsightsCache {
     } catch (e) {
       assertError(e);
       this.logger.warn(`Error getting cache entry ${path}: ${e.message}`);
-      this.logger.debug(e.stack);
+      this.logger.debug(e.stack || '-');
       return undefined;
     }
   }

--- a/plugins/cost-insights/backend/src/plugin.ts
+++ b/plugins/cost-insights/backend/src/plugin.ts
@@ -11,16 +11,13 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   createBackendPlugin,
   coreServices,
 } from '@backstage/backend-plugin-api';
-import { createRouter } from './service/router';
+import { costInsightsAwsServiceRef, createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
-import { CostExplorerCostInsightsAwsService } from './service';
 import { readCostInsightsAwsConfig } from './config';
-import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 
 export const costInsightsAwsPlugin = createBackendPlugin({
   pluginId: 'cost-insights-aws',
@@ -35,33 +32,23 @@ export const costInsightsAwsPlugin = createBackendPlugin({
         discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
         cache: coreServices.cache,
+        costInsightsAwsService: costInsightsAwsServiceRef,
       },
       async init({
         logger,
         httpRouter,
         config,
-        catalogApi,
         auth,
         httpAuth,
         discovery,
         cache,
+        costInsightsAwsService,
       }) {
-        const winstonLogger = loggerToWinstonLogger(logger);
-
         const pluginConfig = readCostInsightsAwsConfig(config);
 
-        const costInsightsAwsService =
-          await CostExplorerCostInsightsAwsService.fromConfig(pluginConfig, {
-            catalogApi,
-            auth,
-            httpAuth,
-            discovery,
-            logger: winstonLogger,
-            credentialsManager: DefaultAwsCredentialsManager.fromConfig(config),
-          });
         httpRouter.use(
           await createRouter({
-            logger: winstonLogger,
+            logger,
             costInsightsAwsService,
             discovery,
             auth,

--- a/plugins/cost-insights/backend/src/service/router.ts
+++ b/plugins/cost-insights/backend/src/service/router.ts
@@ -17,19 +17,19 @@ import {
 } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
-import { Logger } from 'winston';
 import { CostInsightsAwsService } from './types';
 import {
   AuthService,
   CacheService,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 import { CostInsightsCache } from '../cache';
 import { CostInsightsAwsConfig } from '../config';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: LoggerService;
   costInsightsAwsService: CostInsightsAwsService;
   discovery: DiscoveryService;
   auth?: AuthService;

--- a/plugins/ecs/backend/src/plugin.ts
+++ b/plugins/ecs/backend/src/plugin.ts
@@ -11,14 +11,12 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   createBackendPlugin,
   coreServices,
 } from '@backstage/backend-plugin-api';
-import { createRouter } from './service/router';
+import { amazonEcsServiceRef, createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
-import { DefaultAmazonEcsService } from './service';
 
 export const amazonEcsPlugin = createBackendPlugin({
   pluginId: 'amazon-ecs',
@@ -32,28 +30,19 @@ export const amazonEcsPlugin = createBackendPlugin({
         auth: coreServices.auth,
         discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
+        amazonEcsApi: amazonEcsServiceRef,
       },
       async init({
         logger,
         httpRouter,
-        config,
-        catalogApi,
         auth,
         httpAuth,
         discovery,
+        amazonEcsApi,
       }) {
-        const winstonLogger = loggerToWinstonLogger(logger);
-
-        const amazonEcsApi = await DefaultAmazonEcsService.fromConfig(config, {
-          catalogApi,
-          auth,
-          httpAuth,
-          discovery,
-          logger: winstonLogger,
-        });
         httpRouter.use(
           await createRouter({
-            logger: winstonLogger,
+            logger,
             amazonEcsApi,
             discovery,
             auth,

--- a/plugins/ecs/backend/src/service/DefaultAmazonEcsService.ts
+++ b/plugins/ecs/backend/src/service/DefaultAmazonEcsService.ts
@@ -11,7 +11,6 @@
  * limitations under the License.
  */
 
-import { Logger } from 'winston';
 import {
   ECSClient,
   DescribeServicesCommand,
@@ -48,14 +47,19 @@ import { Config } from '@backstage/config';
 import {
   AuthService,
   BackstageCredentials,
+  coreServices,
+  createServiceFactory,
+  createServiceRef,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 import { createLegacyAuthAdapters } from '@backstage/backend-common';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 
 export class DefaultAmazonEcsService implements AmazonECSService {
   public constructor(
-    private readonly logger: Logger,
+    private readonly logger: LoggerService,
     private readonly auth: AuthService,
     private readonly catalogApi: CatalogApi,
     private readonly resourceLocator: AwsResourceLocator,
@@ -69,7 +73,7 @@ export class DefaultAmazonEcsService implements AmazonECSService {
       discovery: DiscoveryService;
       auth?: AuthService;
       httpAuth?: HttpAuthService;
-      logger: Logger;
+      logger: LoggerService;
       resourceLocator?: AwsResourceLocator;
     },
   ) {
@@ -265,3 +269,30 @@ export class DefaultAmazonEcsService implements AmazonECSService {
     return serviceNames;
   }
 }
+
+export const amazonEcsServiceRef = createServiceRef<AmazonECSService>({
+  id: 'amazon-ecs.api',
+  defaultFactory: async service =>
+    createServiceFactory({
+      service,
+      deps: {
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+        catalogApi: catalogServiceRef,
+        auth: coreServices.auth,
+        discovery: coreServices.discovery,
+        httpAuth: coreServices.httpAuth,
+      },
+      async factory({ logger, config, catalogApi, auth, httpAuth, discovery }) {
+        const impl = await DefaultAmazonEcsService.fromConfig(config, {
+          catalogApi,
+          auth,
+          httpAuth,
+          discovery,
+          logger,
+        });
+
+        return impl;
+      },
+    }),
+});

--- a/plugins/ecs/backend/src/service/router.ts
+++ b/plugins/ecs/backend/src/service/router.ts
@@ -17,16 +17,16 @@ import {
 } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
-import { Logger } from 'winston';
 import { AmazonECSService } from './types';
 import {
   AuthService,
   DiscoveryService,
   HttpAuthService,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: LoggerService;
   amazonEcsApi: AmazonECSService;
   discovery: DiscoveryService;
   auth?: AuthService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2497,6 +2497,7 @@ __metadata:
     "@aws-sdk/types": "npm:^3.511.0"
     "@aws/aws-core-plugin-for-backstage-common": "workspace:^"
     "@backstage/backend-common": "npm:^0.24.0"
+    "@backstage/backend-plugin-api": "npm:^0.8.1"
     "@backstage/cli": "npm:^0.27.0"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/integration-aws-node": "npm:^0.1.12"
@@ -4564,6 +4565,83 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-common@npm:^0.24.1":
+  version: 0.24.1
+  resolution: "@backstage/backend-common@npm:0.24.1"
+  dependencies:
+    "@aws-sdk/abort-controller": "npm:^3.347.0"
+    "@aws-sdk/client-codecommit": "npm:^3.350.0"
+    "@aws-sdk/client-s3": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@backstage/backend-dev-utils": "npm:^0.1.5"
+    "@backstage/backend-plugin-api": "npm:^0.8.1"
+    "@backstage/cli-common": "npm:^0.1.14"
+    "@backstage/config": "npm:^1.2.0"
+    "@backstage/config-loader": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.2.4"
+    "@backstage/integration": "npm:^1.14.0"
+    "@backstage/integration-aws-node": "npm:^0.1.12"
+    "@backstage/plugin-auth-node": "npm:^0.5.1"
+    "@backstage/types": "npm:^1.1.1"
+    "@google-cloud/storage": "npm:^7.0.0"
+    "@keyv/memcache": "npm:^1.3.5"
+    "@keyv/redis": "npm:^2.5.3"
+    "@kubernetes/client-node": "npm:0.20.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@octokit/rest": "npm:^19.0.3"
+    "@types/cors": "npm:^2.8.6"
+    "@types/dockerode": "npm:^3.3.0"
+    "@types/express": "npm:^4.17.6"
+    "@types/luxon": "npm:^3.0.0"
+    "@types/webpack-env": "npm:^1.15.2"
+    archiver: "npm:^6.0.0"
+    base64-stream: "npm:^1.0.0"
+    compression: "npm:^1.7.4"
+    concat-stream: "npm:^2.0.0"
+    cors: "npm:^2.8.5"
+    dockerode: "npm:^4.0.0"
+    express: "npm:^4.17.1"
+    express-promise-router: "npm:^4.1.0"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^14.0.0"
+    helmet: "npm:^6.0.0"
+    isomorphic-git: "npm:^1.23.0"
+    jose: "npm:^5.0.0"
+    keyv: "npm:^4.5.2"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    logform: "npm:^2.3.2"
+    luxon: "npm:^3.0.0"
+    minimatch: "npm:^9.0.0"
+    minimist: "npm:^1.2.5"
+    morgan: "npm:^1.10.0"
+    mysql2: "npm:^3.0.0"
+    node-fetch: "npm:^2.7.0"
+    node-forge: "npm:^1.3.1"
+    p-limit: "npm:^3.1.0"
+    path-to-regexp: "npm:^6.2.1"
+    pg: "npm:^8.11.3"
+    pg-format: "npm:^1.0.4"
+    raw-body: "npm:^2.4.1"
+    selfsigned: "npm:^2.0.0"
+    stoppable: "npm:^1.1.0"
+    tar: "npm:^6.1.12"
+    triple-beam: "npm:^1.4.1"
+    uuid: "npm:^9.0.0"
+    winston: "npm:^3.2.1"
+    winston-transport: "npm:^4.5.0"
+    yauzl: "npm:^3.0.0"
+    yn: "npm:^4.0.0"
+  peerDependencies:
+    pg-connection-string: ^2.3.0
+  peerDependenciesMeta:
+    pg-connection-string:
+      optional: true
+  checksum: 10c0/dd5a21850cf9e031eb0e026416bada8cb3389412f97a1fd1f8b66454fbc54721590f7830c898fcab64314530d7d8cad075ba55b658d69162306460aa44b4037e
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-defaults@npm:^0.4.2, @backstage/backend-defaults@npm:^0.4.3":
   version: 0.4.3
   resolution: "@backstage/backend-defaults@npm:0.4.3"
@@ -4683,6 +4761,25 @@ __metadata:
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
   checksum: 10c0/ce42f2243a86e5c093d35ea12c8ae621ad743ab479f250df74ba3d841d0e877cfffed96c454f0015ccd91098e87f47adeff880e5a63a2ba1d87aa6baf3c633f2
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@backstage/backend-plugin-api@npm:0.8.1"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.1.14"
+    "@backstage/config": "npm:^1.2.0"
+    "@backstage/errors": "npm:^1.2.4"
+    "@backstage/plugin-auth-node": "npm:^0.5.1"
+    "@backstage/plugin-permission-common": "npm:^0.8.1"
+    "@backstage/types": "npm:^1.1.1"
+    "@types/express": "npm:^4.17.6"
+    "@types/luxon": "npm:^3.0.0"
+    express: "npm:^4.17.1"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+  checksum: 10c0/14fbd1ce8b0f18b672479b6c0e49a57ff7a77cc965fe9928dc5ff6af31b8c8ee968b912bc3b32c26509578649d67b7717aef4c7a32017dcaaf9425e89e75e9da
   languageName: node
   linkType: hard
 
@@ -5747,6 +5844,31 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.21.4"
   checksum: 10c0/6b4f1c832d6adb59278f6f9dbf8042d8d8b45758ddf9e32b7b91e6d280076dcd722bb6713bb304c93d815ea1a2a1c5d00de53ace79924a1e847309ca108f8a8a
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-node@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@backstage/plugin-auth-node@npm:0.5.1"
+  dependencies:
+    "@backstage/backend-common": "npm:^0.24.1"
+    "@backstage/backend-plugin-api": "npm:^0.8.1"
+    "@backstage/catalog-client": "npm:^1.6.6"
+    "@backstage/catalog-model": "npm:^1.6.0"
+    "@backstage/config": "npm:^1.2.0"
+    "@backstage/errors": "npm:^1.2.4"
+    "@backstage/types": "npm:^1.1.1"
+    "@types/express": "npm:*"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.17.1"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    node-fetch: "npm:^2.7.0"
+    passport: "npm:^0.7.0"
+    winston: "npm:^3.2.1"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  checksum: 10c0/9e3e914a81720f6108619b5bc53ef5d8c00075fc86d959f9b181150a9befd93e996335af913f372cecb8b48c7e85a3ee02a7d611907340dffd25612e8abd80e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Allows other plugins to reference the APIs in the various backend plugins using dependency injection.

### Description of changes

Declares a service reference for the API in each relevant backend plugin package.

Also migrates from winston to LoggerService.

### Description of how you validated changes

Automated + manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
