### PR TITLE
fix: Better handle parsing CodePipeline revision

### DIFF
--- a/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.test.tsx
+++ b/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.test.tsx
@@ -1,3 +1,16 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { CodePipelineExecutions } from '.';

--- a/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.tsx
+++ b/plugins/codepipeline/frontend/src/components/CodePipelineExecutions/CodePipelineExecutions.tsx
@@ -36,7 +36,7 @@ import { parse } from '@aws-sdk/util-arn-parser';
 const renderTrigger = (
   row: Partial<PipelineExecutionSummary>,
 ): React.ReactNode => {
-  if (row.sourceRevisions === undefined) {
+  if (!row.sourceRevisions) {
     return (
       <Typography variant="body2" noWrap>
         -
@@ -50,21 +50,12 @@ const renderTrigger = (
     const sourceRevision = row.sourceRevisions[0];
 
     if (sourceRevision.revisionSummary) {
-      switch (sourceRevision.actionName) {
-        case 'SourceAction':
-          commitMessage = sourceRevision.revisionSummary || '';
-          break;
-        case 'Source':
-          commitMessage = sourceRevision.revisionSummary || '';
-          break;
-        case 'Checkout': {
-          const summary = JSON.parse(sourceRevision.revisionSummary || '{}');
+      try {
+        const summary = JSON.parse(sourceRevision.revisionSummary || '{}');
 
-          commitMessage = summary.CommitMessage;
-          break;
-        }
-        default:
-          break;
+        commitMessage = summary.CommitMessage;
+      } catch (e: any) {
+        commitMessage = sourceRevision.revisionSummary;
       }
     }
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The logic to parse the revision summary isn't quite right and results in the column showing a JSON string in certain cases.

### Description of changes

Changed the logic to always try to parse the revision summary string as JSON, and handle that appropriately. Otherwise treat it as a string.

### Description of how you validated changes

Local testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
