### PR TITLE
docs: Remove instructions for old backend

### DIFF
--- a/plugins/codebuild/README.md
+++ b/plugins/codebuild/README.md
@@ -49,8 +49,6 @@ Install the backend package in your Backstage app:
 yarn workspace backend add @aws/aws-codebuild-plugin-for-backstage-backend
 ```
 
-#### New backend
-
 Add the plugin to the `packages/backend/src/index.ts`:
 
 ```typescript
@@ -59,51 +57,6 @@ const backend = createBackend();
 backend.add(import('@aws/aws-codebuild-plugin-for-backstage-backend'));
 // ...
 backend.start();
-```
-
-#### Old backend
-
-Create a file `packages/backend/src/plugins/codebuild.ts` with the following content:
-
-```typescript
-import {
-  createRouter,
-  DefaultAwsCodeBuildService,
-} from '@aws/aws-codebuild-plugin-for-backstage-backend';
-import { CatalogClient } from '@backstage/catalog-client';
-import { PluginEnvironment } from '../types';
-
-export default async function createPlugin(env: PluginEnvironment) {
-  const catalogApi = new CatalogClient({ discoveryApi: env.discovery });
-  const awsCodeBuildApi = await DefaultAwsCodeBuildService.fromConfig(
-    env.config,
-    {
-      catalogApi,
-      discovery: env.discovery,
-      logger: env.logger,
-    },
-  );
-  return createRouter({
-    logger: env.logger,
-    discovery: env.discovery,
-    awsCodeBuildApi,
-  });
-}
-```
-
-Edit `packages/backend/src/index.ts` to register the backend plugin:
-
-```typescript
-// ..
-import codebuild from './plugins/codebuild';
-
-async function main() {
-  // ...
-  const codebuildEnv = useHotMemoize(module, () => createEnv('aws-codebuild'));
-  // ...
-  apiRouter.use('/aws-codebuild', await codebuild(codebuildEnv));
-  // ...
-}
 ```
 
 Verify that the backend plugin is running in your Backstage app. You should receive `{"status":"ok"}` when accessing this URL:

--- a/plugins/codepipeline/README.md
+++ b/plugins/codepipeline/README.md
@@ -49,8 +49,6 @@ Install the backend package in your Backstage app:
 yarn workspace backend add @aws/aws-codepipeline-plugin-for-backstage-backend
 ```
 
-#### New backend
-
 Add the plugin to the `packages/backend/src/index.ts`:
 
 ```typescript
@@ -59,53 +57,6 @@ const backend = createBackend();
 backend.add(import('@aws/aws-codepipeline-plugin-for-backstage-backend'));
 // ...
 backend.start();
-```
-
-#### Old backend
-
-Create a file `packages/backend/src/plugins/codepipeline.ts` with the following content:
-
-```typescript
-import {
-  createRouter,
-  DefaultAwsCodePipelineService,
-} from '@aws/aws-codepipeline-plugin-for-backstage-backend';
-import { CatalogClient } from '@backstage/catalog-client';
-import { PluginEnvironment } from '../types';
-
-export default async function createPlugin(env: PluginEnvironment) {
-  const catalogApi = new CatalogClient({ discoveryApi: env.discovery });
-  const awsCodePipelineApi = await DefaultAwsCodePipelineService.fromConfig(
-    env.config,
-    {
-      catalogApi,
-      discovery: env.discovery,
-      logger: env.logger,
-    },
-  );
-  return createRouter({
-    logger: env.logger,
-    discovery: env.discovery,
-    awsCodePipelineApi,
-  });
-}
-```
-
-Edit `packages/backend/src/index.ts` to register the backend plugin:
-
-```typescript
-// ..
-import codepipeline from './plugins/codepipeline';
-
-async function main() {
-  // ...
-  const codepipelineEnv = useHotMemoize(module, () =>
-    createEnv('aws-codepipeline'),
-  );
-  // ...
-  apiRouter.use('/aws-codepipeline', await codepipeline(codepipelineEnv));
-  // ...
-}
 ```
 
 Verify that the backend plugin is running in your Backstage app. You should receive `{"status":"ok"}` when accessing this URL:

--- a/plugins/core/scaffolder-actions/README.md
+++ b/plugins/core/scaffolder-actions/README.md
@@ -19,8 +19,6 @@ Install the backend package in your Backstage app:
 yarn workspace backend add @aws/aws-core-plugin-for-backstage-scaffolder-actions
 ```
 
-### New backend
-
 Add the scaffolder module to the `packages/backend/src/index.ts`:
 
 ```typescript
@@ -29,54 +27,6 @@ const backend = createBackend();
 backend.add(import('@aws/aws-core-plugin-for-backstage-scaffolder-actions'));
 // ...
 backend.start();
-```
-
-### Old backend
-
-Update the file `packages/backend/src/plugins/scaffolder.ts` to add the scaffolder actions needed, for example:
-
-```typescript
-import { CatalogClient } from '@backstage/catalog-client';
-import { createRouter } from '@backstage/plugin-scaffolder-backend';
-import { Router } from 'express';
-import type { PluginEnvironment } from '../types';
-import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
-import { ScmIntegrations } from '@backstage/integration';
-import { createAwsCloudControlCreateAction } from '@aws/aws-core-plugin-for-backstage-scaffolder-actions';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const catalogClient = new CatalogClient({
-    discoveryApi: env.discovery,
-  });
-
-  const integrations = ScmIntegrations.fromConfig(env.config);
-
-  const builtInActions = createBuiltinActions({
-    integrations,
-    catalogClient,
-    config: env.config,
-    reader: env.reader,
-  });
-
-  const actions = [
-    ...builtInActions,
-    // Add the new scaffolder action along side other custom actions
-    createAwsCloudControlCreateAction(),
-  ];
-
-  return await createRouter({
-    actions,
-    logger: env.logger,
-    config: env.config,
-    database: env.database,
-    reader: env.reader,
-    catalogClient,
-    identity: env.identity,
-    permissions: env.permissions,
-  });
-}
 ```
 
 ## Actions

--- a/plugins/ecs/README.md
+++ b/plugins/ecs/README.md
@@ -50,8 +50,6 @@ Install the backend package in your Backstage app:
 yarn workspace backend add @aws/amazon-ecs-plugin-for-backstage-backend
 ```
 
-#### New backend
-
 Add the plugin to the `packages/backend/src/index.ts`:
 
 ```typescript
@@ -60,48 +58,6 @@ const backend = createBackend();
 backend.add(import('@aws/amazon-ecs-plugin-for-backstage-backend'));
 // ...
 backend.start();
-```
-
-#### Old backend
-
-Create a file `packages/backend/src/plugins/ecs.ts` with the following content:
-
-```typescript
-import {
-  createRouter,
-  DefaultAmazonEcsService,
-} from '@aws/amazon-ecs-plugin-for-backstage-backend';
-import { CatalogClient } from '@backstage/catalog-client';
-import { PluginEnvironment } from '../types';
-
-export default async function createPlugin(env: PluginEnvironment) {
-  const catalogApi = new CatalogClient({ discoveryApi: env.discovery });
-  const amazonEcsApi = await DefaultAmazonEcsService.fromConfig(env.config, {
-    catalogApi,
-    discovery: env.discovery,
-    logger: env.logger,
-  });
-  return createRouter({
-    logger: env.logger,
-    discovery: env.discovery,
-    amazonEcsApi,
-  });
-}
-```
-
-Edit `packages/backend/src/index.ts` to register the backend plugin:
-
-```typescript
-// ..
-import ecs from './plugins/ecs';
-
-async function main() {
-  // ...
-  const ecsEnv = useHotMemoize(module, () => createEnv('amazon-ecs'));
-  // ...
-  apiRouter.use('/amazon-ecs', await ecs(ecsEnv));
-  // ...
-}
 ```
 
 Verify that the backend plugin is running in your Backstage app. You should receive `{"status":"ok"}` when accessing this URL:


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Seems like we only need to document the new backend system now, user should be migrating.

### Description of changes

Removes installation documentation for old backend system.

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
