### PR TITLE
fix: Allow periods and slashes in transform field names

### DIFF
--- a/plugins/core/catalog-config/src/providers/AwsConfigInfrastructureProvider.test.ts
+++ b/plugins/core/catalog-config/src/providers/AwsConfigInfrastructureProvider.test.ts
@@ -252,6 +252,9 @@ describe('AwsConfigInfrastructureProvider', () => {
           component: 'app1',
           system: 'some-system',
           metadataName: 'test1-111',
+          annotations: {
+            'aws.amazon.com/account-id': '111',
+          },
         }),
         createResource({
           name: 'test2',
@@ -262,6 +265,9 @@ describe('AwsConfigInfrastructureProvider', () => {
           type: 'ecs-service-custom',
           system: 'some-system',
           metadataName: 'test2-222',
+          annotations: {
+            'aws.amazon.com/account-id': '222',
+          },
         }),
       ],
       "SELECT resourceId, resourceName, resourceType, awsRegion, accountId, arn, tags, configuration WHERE resourceType IN ('AWS::ECS::Cluster')",
@@ -280,6 +286,7 @@ function createResource({
   component,
   system,
   metadataName,
+  annotations = {},
 }: {
   name: string;
   accountId: string;
@@ -291,6 +298,7 @@ function createResource({
   component?: string;
   system?: string;
   metadataName?: string;
+  annotations?: any;
 }) {
   const arn = `arn:aws:xxx:${region}:${accountId}:/${name}`;
   const location = `aws-config-provider:${providerId}`;
@@ -308,6 +316,7 @@ function createResource({
           'aws.amazon.com/resource-type': resourceType,
           'backstage.io/managed-by-location': location,
           'backstage.io/managed-by-origin-location': location,
+          ...annotations,
         },
         name: metadataName ?? name,
         description: `AWS Config Resource ${resourceType} ${name}`,

--- a/plugins/core/catalog-config/src/providers/AwsConfigInfrastructureProvider.test.ts
+++ b/plugins/core/catalog-config/src/providers/AwsConfigInfrastructureProvider.test.ts
@@ -226,6 +226,11 @@ describe('AwsConfigInfrastructureProvider', () => {
               expression:
                 "$join([$resource.resourceName, $resource.accountId], '-')",
             },
+            annotations: {
+              'aws.amazon.com/account-id': {
+                expression: '$resource.accountId',
+              },
+            },
             spec: {
               owner: { tag: 'owner' },
               system: { value: 'some-system' },


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Current if you try to use the Config catalog entity provider and try to set annotations that contains slashes you get an error:

```
Invalid config key 'aws.amazon.com/account-id'
```

Periods will also be parsed as nested fields due to the way the Backstage ConfigReader object [reads](https://github.com/backstage/backstage/blob/bc018aa540782987856f73280d6406bb591877d4/packages/config/src/reader.ts#L403) and validates configuration values.

This makes it impossible to implement EKS cluster catalog discovery with the provider since the annotations use periods and slashes in the names.

### Description of changes

This change re-implements the function that loads configuration for field transforms to access fields on the underlying `JsonObject` instead of using the higher-level functions on ConfigReader.

### Description of how you validated changes

Updated unit tests to cover this scenario.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
