### PR TITLE
feat: Support OpenAI compatible APIs

### DIFF
--- a/plugins/genai/agent-langgraph/README.md
+++ b/plugins/genai/agent-langgraph/README.md
@@ -51,7 +51,7 @@ genai:
           region: us-west-2 # (Required) Bedrock AWS region
         # OpenAI only
         openai:
-          baseUrl: ${OPENAI_API_BASE_URL}
           apiKey: ${OPENAI_API_KEY} # (Required) OpenAI model name
           modelName: 'gpt-3.5-turbo-instruct' # (Optional) OpenAI model name
+          baseUrl: ${OPENAI_API_BASE_URL} # (Optional) URL for OpenAI API endpoint
 ```

--- a/plugins/genai/agent-langgraph/README.md
+++ b/plugins/genai/agent-langgraph/README.md
@@ -51,6 +51,7 @@ genai:
           region: us-west-2 # (Required) Bedrock AWS region
         # OpenAI only
         openai:
+          baseUrl: ${OPENAI_API_BASE_URL}
           apiKey: ${OPENAI_API_KEY} # (Required) OpenAI model name
           modelName: 'gpt-3.5-turbo-instruct' # (Optional) OpenAI model name
 ```

--- a/plugins/genai/agent-langgraph/config.d.ts
+++ b/plugins/genai/agent-langgraph/config.d.ts
@@ -59,6 +59,10 @@ export interface Config {
              * (Optional) Name of the OpenAI model to use
              */
             modelName?: string;
+            /**
+             * (Optional) Base URL of the OpenAI API
+             */
+            baseUrl?: string;
           };
         };
       };

--- a/plugins/genai/agent-langgraph/src/LangGraphReactAgentType.ts
+++ b/plugins/genai/agent-langgraph/src/LangGraphReactAgentType.ts
@@ -84,8 +84,10 @@ export class LangGraphReactAgentType implements AgentType {
       agentModel =
         LangGraphReactAgentType.createBedrockModel(agentLangGraphConfig);
     } else if (agentLangGraphConfig.openai) {
-      agentModel =
-        LangGraphReactAgentType.createOpenAIModel(agentLangGraphConfig, logger);
+      agentModel = LangGraphReactAgentType.createOpenAIModel(
+        agentLangGraphConfig,
+        logger,
+      );
     } else {
       throw new Error('No agent model configured');
     }
@@ -133,15 +135,16 @@ export class LangGraphReactAgentType implements AgentType {
     });
   }
 
-  private static createOpenAIModel(config: LangGraphAgentConfig, logger: LoggerService,) {
+  private static createOpenAIModel(
+    config: LangGraphAgentConfig,
+    logger: LoggerService,
+  ) {
     const { modelName, apiKey } = config.openai!;
 
-    const baseUrl= config.openai?.baseUrl ?? 'https://api.openai.com/v1'
-    
+    const baseUrl = config.openai?.baseUrl ?? 'https://api.openai.com/v1';
+
     logger.info(
-      `Instantiating ChatOpenAI model '${
-        modelName
-      }' using baseUrl '${baseUrl}'`,
+      `Instantiating ChatOpenAI model '${modelName}' using baseUrl '${baseUrl}'`,
     );
 
     return new ChatOpenAI({

--- a/plugins/genai/agent-langgraph/src/LangGraphReactAgentType.ts
+++ b/plugins/genai/agent-langgraph/src/LangGraphReactAgentType.ts
@@ -85,7 +85,7 @@ export class LangGraphReactAgentType implements AgentType {
         LangGraphReactAgentType.createBedrockModel(agentLangGraphConfig);
     } else if (agentLangGraphConfig.openai) {
       agentModel =
-        LangGraphReactAgentType.createOpenAIModel(agentLangGraphConfig);
+        LangGraphReactAgentType.createOpenAIModel(agentLangGraphConfig, logger);
     } else {
       throw new Error('No agent model configured');
     }
@@ -133,10 +133,21 @@ export class LangGraphReactAgentType implements AgentType {
     });
   }
 
-  private static createOpenAIModel(config: LangGraphAgentConfig) {
+  private static createOpenAIModel(config: LangGraphAgentConfig, logger: LoggerService,) {
     const { modelName, apiKey } = config.openai!;
 
+    const baseUrl= config.openai?.baseUrl ?? 'https://api.openai.com/v1'
+    
+    logger.info(
+      `Instantiating ChatOpenAI model '${
+        modelName
+      }' using baseUrl '${baseUrl}'`,
+    );
+
     return new ChatOpenAI({
+      configuration: {
+        baseURL: baseUrl,
+      },
       apiKey: apiKey,
       streaming: true,
       modelName: modelName,

--- a/plugins/genai/agent-langgraph/src/config/config.ts
+++ b/plugins/genai/agent-langgraph/src/config/config.ts
@@ -87,5 +87,6 @@ export function readLangGraphAgentOpenAIConfig(
   return {
     apiKey: config.getString('apiKey'),
     modelName: config.getOptionalString('modelName'),
+    baseUrl: config.getOptionalString('baseUrl'),
   };
 }

--- a/plugins/genai/agent-langgraph/src/config/types.ts
+++ b/plugins/genai/agent-langgraph/src/config/types.ts
@@ -39,4 +39,5 @@ export interface LangGraphAgentBedrockConfig {
 export interface LangGraphAgentOpenAIConfig {
   apiKey: string;
   modelName?: string;
+  baseUrl?: string;
 }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #316

### Reason for this change

Need to be able to support frameworks such as Ollama which provide an [OpenAI compatible interface](https://github.com/ollama/ollama/blob/main/docs/openai.md).

Therefore, it would make sense to be able to configure another `baseUrl` parameter for the endpoints than the default OpenAI endpoint (<https://api.openai.com/v1>).

### Description of changes

I the needed code to add a new `langgraph.openai.baseUrl` parameter in the settings of the `aws-genai` plugin, that would look like this:

```yaml
genai:
  agents:
    general: # This matches the URL in the frontend
      description: ...
      prompt: ...
      langgraph:
        openai:
          baseUrl: ${OPENAI_API_BASE_URL}
          apiKey: ${OPENAI_API_KEY}
          modelName: ${QUERY_MODEL_NAME}
```
### Description of how you validated changes

Only tested it locally on my dev host at this point.


### Checklist

- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
