### PR TITLE
docs: Fix reference to backstageTechDocsSearch

### DIFF
--- a/plugins/genai/README.md
+++ b/plugins/genai/README.md
@@ -161,7 +161,7 @@ Access the application in your browser and select the "Chat Assistant" option in
 
 We can provide tools/functions that can be called by agents to retrieve context or perform actions. Tools can be added to the agent using a Backstage extension point and packaged as NPM packages.
 
-There are several tools built in to the plugin related to core Backstage functionality. The `backstageCatalogSearch`, `backstageEntity` and `backstageTechdocsSearch` tools to give the model basic access to the Backstage catalog and TechDocs documentation.
+There are several tools built in to the plugin related to core Backstage functionality. The `backstageCatalogSearch`, `backstageEntity` and `backstageTechDocsSearch` tools to give the model basic access to the Backstage catalog and TechDocs documentation.
 
 Update the previous agent definition to add the `tools` field:
 
@@ -172,10 +172,10 @@ genai:
       description: [...]
       prompt: [...]
       langgraph: [...]
-      tool:
+      tools:
         - backstageCatalogSearch
         - backstageEntity
-        - backstageTechdocsSearch
+        - backstageTechDocsSearch
 ```
 
 Restart Backstage to reload the configuration and try asking the chat assistant a question related to information in the your Backstage catalog, for example "Summarize <component name> from the Backstage catalog".

--- a/plugins/genai/docs/tools.md
+++ b/plugins/genai/docs/tools.md
@@ -8,7 +8,7 @@ The term "tool use" or "function calling" describes a mechanism where an LLM is 
 | ---------- | ------------------------- | -------------------------------------------------------------------- |
 | (built-in) | `backstageCatalogSearch`  | Search the Backstage catalog using the Search API                    |
 |            | `backstageEntity`         | Retrieve information about a specific entity through the Catalog API |
-|            | `backstageTechdocsSearch` | Search TechDocs documentation using the Search API                   |
+|            | `backstageTechDocsSearch` | Search TechDocs documentation using the Search API                   |
 
 ## Creating tools
 


### PR DESCRIPTION

### Reason for this change

There are some critical errors in the doc explaining how to use genai plugin tools:
- the parameter `tool` for the default general agent is mentioned instead of `tools`
- the name of the tool `backstageTechdocsSearch` has an error too. The right name of the provided tool is `backstageTechDocsSearch`

### Description of changes

Fix the errors in the docs.

### Description of how you validated changes

No but this issue impacts only the doc files.

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
