### PR TITLE
fix: Use correct date format for costs

### DIFF
--- a/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
+++ b/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
@@ -247,7 +247,7 @@ export class CostExplorerCostInsightsAwsService
 
     const aggregation = response.ResultsByTime!.map(result => {
       return {
-        date: result.TimePeriod!.Start!.replaceAll('-', '/'),
+        date: result.TimePeriod!.Start!,
         amount: parseFloat(result.Total!.UnblendedCost.Amount!),
       };
     });
@@ -283,7 +283,7 @@ export class CostExplorerCostInsightsAwsService
 
     for (let i = 0; i < response.ResultsByTime!.length; i++) {
       const result = response.ResultsByTime![i];
-      const resultDate = result.TimePeriod!.Start!.replaceAll('-', '/');
+      const resultDate = result.TimePeriod!.Start!;
 
       for (let j = 0; j < result.Groups!.length; j++) {
         const groupResult = result.Groups![j];


### PR DESCRIPTION
### Issue # (if applicable)

Closes #323 

### Reason for this change

Parsing logic in upstream cost insights plugin expects dates of format yyyy-mm-dd not yyyy/mm/dd

### Description of changes

Changes format per above

### Description of how you validated changes

Manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
