### PR TITLE
feat(cost-insights): Allow more flexible cost category selection

### DIFF
--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -156,7 +156,7 @@ kind: Component
 metadata:
   # ...
   annotations:
-    aws.amazon.com/cost-insights-cost-categories: myapp-category
+    aws.amazon.com/cost-insights-cost-categories: myapp-category=myapp
 spec:
   type: service
   # ...

--- a/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
+++ b/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
@@ -150,7 +150,10 @@ export class CostExplorerCostInsightsAwsService
 
     let filter: Expression;
 
-    const filterType = annotation.name === COST_INSIGHTS_AWS_TAGS_ANNOTATION ? 'Tags' : 'CostCategories'
+    const filterType =
+      annotation.name === COST_INSIGHTS_AWS_TAGS_ANNOTATION
+        ? 'Tags'
+        : 'CostCategories';
 
     const filters = annotation.value.split(',').map(e => {
       const parts = e.split('=');
@@ -170,7 +173,6 @@ export class CostExplorerCostInsightsAwsService
     } else {
       filter = filters[0];
     }
-    
 
     const { startDate, endDate } = this.parseInterval(options.intervals);
 

--- a/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
+++ b/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
@@ -150,33 +150,27 @@ export class CostExplorerCostInsightsAwsService
 
     let filter: Expression;
 
-    if (annotation.name === COST_INSIGHTS_AWS_TAGS_ANNOTATION) {
-      const tagFilters = annotation.value.split(',').map(e => {
-        const parts = e.split('=');
+		const filterType = annotation.name === COST_INSIGHTS_AWS_TAGS_ANNOTATION ? 'Tags' : 'CostCategories'
 
-        return {
-          Tags: {
-            Key: parts[0],
-            Values: [parts[1]],
-          },
-        };
-      });
+    const filters = annotation.value.split(',').map(e => {
+      const parts = e.split('=');
 
-      if (tagFilters.length > 1) {
-        filter = {
-          And: tagFilters,
-        };
-      } else {
-        filter = tagFilters[0];
-      }
-    } else {
-      filter = {
-        CostCategories: {
-          Key: 'TAG',
-          Values: annotation.value.split(','),
+      return {
+        [filterType]: {
+          Key: parts[0],
+          Values: [parts[1]],
         },
       };
+    });
+
+    if (filters.length > 1) {
+      filter = {
+        And: filters,
+      };
+    } else {
+      filter = filters[0];
     }
+    
 
     const { startDate, endDate } = this.parseInterval(options.intervals);
 

--- a/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
+++ b/plugins/cost-insights/backend/src/service/CostExplorerCostInsightsAwsService.ts
@@ -150,7 +150,7 @@ export class CostExplorerCostInsightsAwsService
 
     let filter: Expression;
 
-		const filterType = annotation.name === COST_INSIGHTS_AWS_TAGS_ANNOTATION ? 'Tags' : 'CostCategories'
+    const filterType = annotation.name === COST_INSIGHTS_AWS_TAGS_ANNOTATION ? 'Tags' : 'CostCategories'
 
     const filters = annotation.value.split(',').map(e => {
       const parts = e.split('=');


### PR DESCRIPTION
### Issue #

Closes #324.

### Reason for this change

Cost Insight backend had hard coded cost category of TAG which didn't make sense for most use cases. Instead make cost category key configurable using the same logic as Tag based filters.

Note that as this changes the way the category annotation is used it is a breaking change.

### Description of changes

Restructures the cost explorer filter logic, so the same logic is logic is used for tags and categories, just with a change to the filter type.

### Description of how you validated changes

Manually tested by repointing included examples and config to my own aws infra. All looks good

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
