### PR TITLE
fix(ecr): prevent scan findings query from failing with multiple arns

### DIFF
--- a/plugins/ecr/backend/src/service/DefaultAmazonEcrService.ts
+++ b/plugins/ecr/backend/src/service/DefaultAmazonEcrService.ts
@@ -188,7 +188,7 @@ export class DefaultAmazonEcrService implements AmazonEcrService {
       credentials,
     });
 
-    if (arns.indexOf(arn) > 0) {
+    if (arns.indexOf(arn) < 0) {
       throw new Error('Repository ARN not found for entity');
     }
 


### PR DESCRIPTION
### Reason for this change

If an entity is linked to multiple ARNs, only one of the ARNs will return a result when retrieving scan findings. The others will throw an error.

### Description of changes

Instead of throwing an error if the index of the ARN exceeds 0, an error is only thrown is the index of the ARN is lower than 0. (if there is no match)

### Description of how you validated changes

I applied a patch in our Backstage instance

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
