### PR TITLE
fix: Correctly use namespaces groups for Cost Insights

### DIFF
--- a/plugins/cost-insights/frontend/src/api/CostExplorerClient.ts
+++ b/plugins/cost-insights/frontend/src/api/CostExplorerClient.ts
@@ -26,7 +26,7 @@ import {
 import dateFormat from 'dateformat';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
-import { parseEntityRef } from '@backstage/catalog-model';
+import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
 import { CatalogApi } from '@backstage/plugin-catalog-react';
 
 export class CostExplorerClient implements CostInsightsApi {
@@ -66,7 +66,7 @@ export class CostExplorerClient implements CostInsightsApi {
       })
     ).items.map(e => {
       return {
-        id: `group:${e.metadata.namespace}/${e.metadata.name}`,
+        id: stringifyEntityRef(e),
         name: e.metadata.name,
       };
     });

--- a/plugins/cost-insights/frontend/src/api/CostExplorerClient.ts
+++ b/plugins/cost-insights/frontend/src/api/CostExplorerClient.ts
@@ -66,7 +66,7 @@ export class CostExplorerClient implements CostInsightsApi {
       })
     ).items.map(e => {
       return {
-        id: `group:${e.metadata.name}`,
+        id: `group:${e.metadata.namespace}/${e.metadata.name}`,
         name: e.metadata.name,
       };
     });


### PR DESCRIPTION
### Reason for this change

Currently only Groups in the default namespace are supported when opening the CostInsightsPage.    
If a Backstage instance uses non-default namespaces e.g. `group:team/a-team` then on opening the plugin still queries `group:default/a-team` which leads to page load failure.  This is as `group:a-team` will be interpreted as the default namespace

### Description of changes

As the Catalog Query api  returns an Entity object, replaced the manual templating with the provided `stringifyEntityRef` function to create an ID.

### Description of how you validated changes



### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
