### PR TITLE
feat: GenAI structured outputs

### DIFF
--- a/plugins/genai/agent-langgraph/src/LangGraphReactAgentType.ts
+++ b/plugins/genai/agent-langgraph/src/LangGraphReactAgentType.ts
@@ -275,11 +275,12 @@ export class LangGraphReactAgentType implements AgentType {
     options: {
       userEntityRef?: CompoundEntityRef;
       credentials?: BackstageCredentials;
+      responseFormat?: Record<string, any>;
     },
   ): Promise<GenerateResponse> {
     const messages: (SystemMessage | HumanMessage)[] = [];
 
-    const { userEntityRef, credentials } = options;
+    const { userEntityRef, credentials, responseFormat } = options;
 
     if (this.prompt) {
       messages.push(this.buildSystemPrompt(this.prompt, userEntityRef));
@@ -292,6 +293,7 @@ export class LangGraphReactAgentType implements AgentType {
     const agent = createReactAgent({
       llm: this.llm,
       tools: this.tools,
+      responseFormat,
     });
     const finalState = await agent.invoke(
       { messages },
@@ -303,6 +305,12 @@ export class LangGraphReactAgentType implements AgentType {
         },
       },
     );
+
+    if (responseFormat) {
+      return {
+        output: finalState.structuredResponse,
+      };
+    }
 
     const outputMessages = finalState.messages.slice(messages.length);
 

--- a/plugins/genai/backend/package.json
+++ b/plugins/genai/backend/package.json
@@ -49,6 +49,7 @@
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "jsonschema": "^1.5.0",
     "knex": "^3.1.0",
     "lodash": "^4.17.21",
     "uuid": "^10.0.0",

--- a/plugins/genai/backend/src/agent/Agent.ts
+++ b/plugins/genai/backend/src/agent/Agent.ts
@@ -100,6 +100,7 @@ export class Agent {
     prompt: string,
     sessionId: string,
     options: {
+      responseFormat?: Record<string, any>;
       userEntityRef?: CompoundEntityRef;
       responseSchema?: any;
       credentials: BackstageCredentials;

--- a/plugins/genai/backend/src/service/DefaultAgentService.ts
+++ b/plugins/genai/backend/src/service/DefaultAgentService.ts
@@ -236,23 +236,27 @@ export class DefaultAgentService implements AgentService {
   async generate(
     prompt: string,
     options: {
+      responseFormat?: Record<string, any>;
       agentName: string;
       credentials: BackstageCredentials<
         BackstageUserPrincipal | BackstageServicePrincipal
       >;
     },
   ): Promise<GenerateResponse> {
+    const { responseFormat, agentName, credentials } = options;
+
     const { principal, userEntityRef } = await this.getUserEntityRef(
-      options.credentials,
+      credentials,
     );
 
-    const agent = this.getActualAgent(options.agentName);
+    const agent = this.getActualAgent(agentName);
 
-    const session = await this.makeSession(options.agentName, principal, true);
+    const session = await this.makeSession(agentName, principal, true);
 
     return agent.generate(prompt, session.sessionId, {
       userEntityRef,
-      credentials: options.credentials,
+      credentials,
+      responseFormat,
     });
   }
 

--- a/plugins/genai/backend/src/service/router.ts
+++ b/plugins/genai/backend/src/service/router.ts
@@ -32,6 +32,7 @@ import {
 } from '@aws/genai-plugin-for-backstage-common';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { McpService } from './McpService';
+import { Validator } from 'jsonschema';
 
 export interface RouterOptions {
   logger: LoggerService;
@@ -99,6 +100,15 @@ export async function createRouter(
 
   router.post('/v1/generate', async (request, response) => {
     const payload = request.body as GenerateRequest;
+
+    if (payload.responseFormat) {
+      try {
+        new Validator().addSchema(payload.responseFormat);
+      } catch (error) {
+        response.status(400).send('Invalid response format schema');
+        return;
+      }
+    }
 
     const credentials = await httpAuth.credentials(request);
 

--- a/plugins/genai/backend/src/service/types.ts
+++ b/plugins/genai/backend/src/service/types.ts
@@ -48,6 +48,7 @@ export interface AgentService {
     options: {
       agentName: string;
       credentials?: BackstageCredentials;
+      responseFormat?: Record<string, any>;
     },
   ): Promise<GenerateResponse>;
 

--- a/plugins/genai/common/src/types.ts
+++ b/plugins/genai/common/src/types.ts
@@ -20,6 +20,7 @@ export interface ChatRequest {
 export interface GenerateRequest {
   prompt: string;
   agentName: string;
+  responseFormat?: Record<string, any>;
 }
 
 export interface AgentRequestOptions {

--- a/plugins/genai/node/src/types.ts
+++ b/plugins/genai/node/src/types.ts
@@ -40,6 +40,7 @@ export interface AgentType {
     sessionId: string,
     logger: LoggerService,
     options: {
+      responseFormat?: Record<string, any>;
       userEntityRef?: CompoundEntityRef;
       credentials: BackstageCredentials;
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,7 @@ __metadata:
     "@types/uuid": "npm:^10"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
+    jsonschema: "npm:^1.5.0"
     knex: "npm:^3.1.0"
     lodash: "npm:^4.17.21"
     msw: "npm:^1.0.0"
@@ -30468,6 +30469,13 @@ __metadata:
   version: 1.4.1
   resolution: "jsonschema@npm:1.4.1"
   checksum: 10c0/c3422d3fc7d33ff7234a806ffa909bb6fb5d1cd664bea229c64a1785dc04cbccd5fc76cf547c6ab6dd7881dbcaf3540a6a9f925a5956c61a9cd3e23a3c1796ef
+  languageName: node
+  linkType: hard
+
+"jsonschema@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "jsonschema@npm:1.5.0"
+  checksum: 10c0/c24ddb8d741f02efc0da3ad9b597a275f6b595062903d3edbfaa535c3f9c4c98613df68da5cb6635ed9aeab30d658986fea61d7662fc5b2b92840d5a1e21235e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The `generate` function in the GenAI plugin should optionally be able to generate real structured outputs for use-cases where this is preferable.

### Description of changes

Adds an optional parameter to the `generate` code path to express a JSON Schema schema that is passed through to the agent implementation. This will the `output` response field being an object matching that schema instead of a raw string.

### Description of how you validated changes

Manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
