### PR TITLE
feat: Added configurable langgraph recursion limit

### DIFF
--- a/plugins/genai/agent-langgraph/README.md
+++ b/plugins/genai/agent-langgraph/README.md
@@ -21,6 +21,7 @@ Global configuration values apply to all agents, all of this is optional:
 genai:
   langgraph:
     memory: # (Optional) Memory store to use
+    recursionLimit: # (Optional) Limit the number of graph supersteps (default 25)
     langfuse: # (Optional) Configuration for LangFuse observability
       baseUrl: http://localhost:3001 # (Required) LangFuse URL
       publicKey: pk-aaa # (Required) Public key

--- a/plugins/genai/agent-langgraph/config.d.ts
+++ b/plugins/genai/agent-langgraph/config.d.ts
@@ -18,6 +18,11 @@ export interface Config {
      */
     memory?: string;
 
+    /**
+     * (Optional) Limit the number of graph supersteps
+     */
+    recursionLimit?: number;
+
     langfuse?: {
       /**
        * (Required) LangFuse base URL

--- a/plugins/genai/agent-langgraph/src/config/config.ts
+++ b/plugins/genai/agent-langgraph/src/config/config.ts
@@ -42,6 +42,7 @@ export function readSharedLangGraphAgentConfig(
 
   return {
     memory: config?.getOptionalString('memory') ?? 'in-memory',
+    recursionLimit: config?.getOptionalNumber('recursionLimit') ?? 25,
     langfuse: langfuseAgentConfig,
   };
 }

--- a/plugins/genai/agent-langgraph/src/config/types.ts
+++ b/plugins/genai/agent-langgraph/src/config/types.ts
@@ -13,6 +13,7 @@
 
 export interface SharedLangGraphAgentConfig {
   memory: string;
+  recursionLimit: number;
   langfuse?: LangGraphAgentLangFuseConfig;
 }
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Puts a default cap on how many steps a single LangGraph agent can execute. This helps limit agents from exhibiting behavior that consumes a large number of tokens.

### Description of changes

Added `recursionLimit` configuration parameter to shared LangGraph configuration. This means configuration can only be applied globally for now, per-agent configuration would require further changes.

### Description of how you validated changes

Manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
