### PR TITLE
feat: Remove reliance on deprecated backend APIs

### DIFF
--- a/plugins/codebuild/backend/package.json
+++ b/plugins/codebuild/backend/package.json
@@ -40,6 +40,7 @@
     "@aws/aws-core-plugin-for-backstage-common": "workspace:^",
     "@aws/aws-core-plugin-for-backstage-node": "workspace:^",
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-plugin-api": "^1.0.2",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/catalog-model": "^1.7.1",
@@ -54,7 +55,6 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-test-utils": "^1.1.0",
     "@backstage/cli": "^0.29.2",
     "@backstage/plugin-auth-backend": "^0.24.0",

--- a/plugins/codebuild/backend/src/plugin.ts
+++ b/plugins/codebuild/backend/src/plugin.ts
@@ -16,7 +16,6 @@ import {
   coreServices,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import { awsCodeBuildServiceRef } from './service/DefaultAwsCodeBuildService';
 
 export const awsCodebuildPlugin = createBackendPlugin({
@@ -27,26 +26,15 @@ export const awsCodebuildPlugin = createBackendPlugin({
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
         config: coreServices.rootConfig,
-        catalogApi: catalogServiceRef,
-        auth: coreServices.auth,
-        discovery: coreServices.discovery,
-        httpAuth: coreServices.httpAuth,
         awsCodeBuildApi: awsCodeBuildServiceRef,
+        httpAuth: coreServices.httpAuth,
       },
-      async init({
-        logger,
-        httpRouter,
-        auth,
-        httpAuth,
-        discovery,
-        awsCodeBuildApi,
-      }) {
+      async init({ logger, httpRouter, httpAuth, awsCodeBuildApi, config }) {
         httpRouter.use(
           await createRouter({
             logger,
             awsCodeBuildApi,
-            discovery,
-            auth,
+            config,
             httpAuth,
           }),
         );

--- a/plugins/codebuild/backend/src/service/router.test.ts
+++ b/plugins/codebuild/backend/src/service/router.test.ts
@@ -11,13 +11,13 @@
  * limitations under the License.
  */
 
-import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
 import { AwsCodeBuildService } from './types';
 import { mockServices } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -27,9 +27,10 @@ describe('createRouter', () => {
 
   beforeAll(async () => {
     const router = await createRouter({
-      logger: getVoidLogger(),
+      logger: mockServices.logger.mock(),
       awsCodeBuildApi: mockService,
-      discovery: mockServices.discovery(),
+      httpAuth: mockServices.httpAuth.mock(),
+      config: new ConfigReader({}),
     });
     app = express().use(router);
   });

--- a/plugins/codepipeline/backend/package.json
+++ b/plugins/codepipeline/backend/package.json
@@ -40,6 +40,7 @@
     "@aws/aws-core-plugin-for-backstage-common": "workspace:^",
     "@aws/aws-core-plugin-for-backstage-node": "workspace:^",
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-plugin-api": "^1.0.2",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/catalog-model": "^1.7.1",
@@ -54,7 +55,6 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-test-utils": "^1.1.0",
     "@backstage/cli": "^0.29.2",
     "@backstage/plugin-auth-backend": "^0.24.0",

--- a/plugins/codepipeline/backend/src/plugin.ts
+++ b/plugins/codepipeline/backend/src/plugin.ts
@@ -16,7 +16,6 @@ import {
   coreServices,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import { awsCodePipelineServiceRef } from './service/DefaultAwsCodePipelineService';
 
 export const awsCodePiplinePlugin = createBackendPlugin({
@@ -27,27 +26,16 @@ export const awsCodePiplinePlugin = createBackendPlugin({
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
         config: coreServices.rootConfig,
-        catalogApi: catalogServiceRef,
-        auth: coreServices.auth,
-        discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
         awsCodePipelineApi: awsCodePipelineServiceRef,
       },
-      async init({
-        logger,
-        httpRouter,
-        auth,
-        httpAuth,
-        discovery,
-        awsCodePipelineApi,
-      }) {
+      async init({ logger, httpRouter, httpAuth, awsCodePipelineApi, config }) {
         httpRouter.use(
           await createRouter({
             logger,
             awsCodePipelineApi,
-            discovery,
-            auth,
             httpAuth,
+            config,
           }),
         );
         httpRouter.addAuthPolicy({

--- a/plugins/codepipeline/backend/src/service/router.test.ts
+++ b/plugins/codepipeline/backend/src/service/router.test.ts
@@ -11,13 +11,13 @@
  * limitations under the License.
  */
 
-import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
 import { AwsCodePipelineService } from './types';
 import { mockServices } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -28,9 +28,10 @@ describe('createRouter', () => {
 
   beforeAll(async () => {
     const router = await createRouter({
-      logger: getVoidLogger(),
+      logger: mockServices.logger.mock(),
       awsCodePipelineApi: mockService,
-      discovery: mockServices.discovery(),
+      httpAuth: mockServices.httpAuth(),
+      config: new ConfigReader({}),
     });
     app = express().use(router);
   });

--- a/plugins/core/scaffolder-actions/src/actions/s3/cp.ts
+++ b/plugins/core/scaffolder-actions/src/actions/s3/cp.ts
@@ -19,7 +19,7 @@ import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import fs from 'fs-extra';
 import { z } from 'zod';
-import { resolveSafeChildPath } from '@backstage/backend-common';
+import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
 import { glob } from 'glob';
 import { AWS_SDK_CUSTOM_USER_AGENT } from '@aws/aws-core-plugin-for-backstage-common';
 

--- a/plugins/ecr/backend/package.json
+++ b/plugins/ecr/backend/package.json
@@ -41,6 +41,7 @@
     "@aws/aws-core-plugin-for-backstage-common": "workspace:^",
     "@aws/aws-core-plugin-for-backstage-node": "workspace:^",
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-plugin-api": "^1.0.2",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/catalog-model": "^1.7.1",
@@ -58,7 +59,6 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-test-utils": "^1.1.0",
     "@backstage/cli": "^0.29.2",
     "@backstage/plugin-auth-backend": "^0.24.0",

--- a/plugins/ecr/backend/src/plugin.ts
+++ b/plugins/ecr/backend/src/plugin.ts
@@ -24,16 +24,16 @@ export const ecrAwsPlugin = createBackendPlugin({
       deps: {
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
-        discovery: coreServices.discovery,
+        config: coreServices.rootConfig,
         httpAuth: coreServices.httpAuth,
         ecrAwsService: amazonEcrServiceRef,
       },
-      async init({ logger, httpRouter, httpAuth, discovery, ecrAwsService }) {
+      async init({ logger, httpRouter, httpAuth, config, ecrAwsService }) {
         httpRouter.use(
           await createRouter({
             logger,
             ecrAwsService,
-            discovery,
+            config,
             httpAuth,
           }),
         );

--- a/plugins/ecs/backend/package.json
+++ b/plugins/ecs/backend/package.json
@@ -40,6 +40,7 @@
     "@aws/aws-core-plugin-for-backstage-common": "workspace:^",
     "@aws/aws-core-plugin-for-backstage-node": "workspace:^",
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-plugin-api": "^1.0.2",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/catalog-model": "^1.7.1",
@@ -54,7 +55,6 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "^0.5.3",
     "@backstage/backend-test-utils": "^1.1.0",
     "@backstage/cli": "^0.29.2",
     "@backstage/plugin-auth-backend": "^0.24.0",

--- a/plugins/ecs/backend/src/plugin.ts
+++ b/plugins/ecs/backend/src/plugin.ts
@@ -16,7 +16,6 @@ import {
   coreServices,
 } from '@backstage/backend-plugin-api';
 import { amazonEcsServiceRef, createRouter } from './service/router';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 
 export const amazonEcsPlugin = createBackendPlugin({
   pluginId: 'amazon-ecs',
@@ -26,26 +25,15 @@ export const amazonEcsPlugin = createBackendPlugin({
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
         config: coreServices.rootConfig,
-        catalogApi: catalogServiceRef,
-        auth: coreServices.auth,
-        discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
         amazonEcsApi: amazonEcsServiceRef,
       },
-      async init({
-        logger,
-        httpRouter,
-        auth,
-        httpAuth,
-        discovery,
-        amazonEcsApi,
-      }) {
+      async init({ logger, httpRouter, httpAuth, amazonEcsApi, config }) {
         httpRouter.use(
           await createRouter({
+            config,
             logger,
             amazonEcsApi,
-            discovery,
-            auth,
             httpAuth,
           }),
         );

--- a/plugins/ecs/backend/src/service/router.test.ts
+++ b/plugins/ecs/backend/src/service/router.test.ts
@@ -11,13 +11,13 @@
  * limitations under the License.
  */
 
-import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
 import { AmazonECSService } from './types';
 import { mockServices } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -27,9 +27,10 @@ describe('createRouter', () => {
 
   beforeAll(async () => {
     const router = await createRouter({
-      logger: getVoidLogger(),
+      logger: mockServices.logger.mock(),
       amazonEcsApi: mockService,
-      discovery: mockServices.discovery(),
+      httpAuth: mockServices.httpAuth.mock(),
+      config: new ConfigReader({}),
     });
     app = express().use(router);
   });


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

Over time the various backend plugins in this repository have accumulated use of now deprecated APIs. Specifically:

1. Using the older `CatalogApi` and `catalogServiceRef`
2. Using the legacy auth adapter to retrieve user auth information

### Description of changes

Mainly:

1. Replaced use of `CatalogApi` with `CatalogService`, which simplifies the services code since it doesn't have to generate a token for the catalog any more
2. Removed any reliance on legacy auth adapter, moving over to `HttpAuthService`
3. Migrated various unit test mocks

### Description of how you validated changes

Unit tests and manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
