### PR TITLE
feat: TechDocs tool improvements

### DIFF
--- a/examples/docs/index.md
+++ b/examples/docs/index.md
@@ -1,0 +1,5 @@
+# Example website
+
+This is some sample documentation for the Example Website.
+
+This is where you would typically document the component for others to understand its purpose and how its built.

--- a/examples/entities.yaml
+++ b/examples/entities.yaml
@@ -19,6 +19,7 @@ metadata:
     aws.amazon.com/amazon-ecs-service-tags: component=example-website
     aws.amazon.com/cost-insights-tags: component=example-website
     aws.amazon.com/amazon-ecr-tags: component=example-website
+    backstage.io/techdocs-ref: dir:.
 spec:
   type: website
   lifecycle: experimental

--- a/examples/mkdocs.yml
+++ b/examples/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: example-website
+docs_dir: docs
+plugins:
+  - techdocs-core

--- a/plugins/genai/backend/package.json
+++ b/plugins/genai/backend/package.json
@@ -44,6 +44,7 @@
     "@backstage/catalog-model": "^1.4.5",
     "@backstage/config": "^1.2.0",
     "@backstage/plugin-catalog-node": "^1.14.0",
+    "@backstage/plugin-search-common": "^1.2.19",
     "@langchain/core": "0.3.57",
     "@modelcontextprotocol/sdk": "^1.12.3",
     "@types/express": "*",
@@ -52,6 +53,8 @@
     "jsonschema": "^1.5.0",
     "knex": "^3.1.0",
     "lodash": "^4.17.21",
+    "node-html-parser": "^7.0.1",
+    "turndown": "^7.2.0",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"
   },
@@ -63,6 +66,7 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.1.2",
     "@types/lodash": "^4",
     "@types/supertest": "^2.0.12",
+    "@types/turndown": "^5.0.5",
     "@types/uuid": "^10",
     "msw": "^1.0.0",
     "supertest": "^6.2.4"

--- a/plugins/genai/backend/src/plugin.ts
+++ b/plugins/genai/backend/src/plugin.ts
@@ -29,6 +29,7 @@ import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import {
   createBackstageCatalogSearchTool,
   createBackstageEntityTool,
+  createBackstageTechDocsReadTool,
   createBackstageTechDocsSearchTool,
 } from './tools';
 import { DatabaseSessionStore } from './database';
@@ -81,6 +82,7 @@ export const awsGenAiPlugin = createBackendPlugin({
         toolkit.add(createBackstageEntityTool(catalogApi));
         toolkit.add(createBackstageCatalogSearchTool(discovery, auth));
         toolkit.add(createBackstageTechDocsSearchTool(discovery, auth));
+        toolkit.add(createBackstageTechDocsReadTool(discovery, auth));
 
         const sessionStore = await DatabaseSessionStore.create({
           database,

--- a/plugins/genai/backend/src/tools/index.ts
+++ b/plugins/genai/backend/src/tools/index.ts
@@ -14,3 +14,4 @@
 export * from './catalogEntityTool';
 export * from './catalogSearchTool';
 export * from './techDocsSearchTool';
+export * from './techDocsReadTool';

--- a/plugins/genai/backend/src/tools/techDocsReadTool.ts
+++ b/plugins/genai/backend/src/tools/techDocsReadTool.ts
@@ -1,0 +1,69 @@
+import {
+  AuthService,
+  BackstageCredentials,
+  DiscoveryService,
+} from '@backstage/backend-plugin-api';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { parse } from 'node-html-parser';
+import TurndownService from 'turndown';
+
+export function createBackstageTechDocsReadTool(
+  discoveryApi: DiscoveryService,
+  auth: AuthService,
+) {
+  return new DynamicStructuredTool({
+    name: 'backstageTechDocsRead',
+    description: `Reads a specific page of Backstage TechDocs technical documentation and returns the content.
+
+The location parameter can be found in TechDocs search results.
+
+Alternatively the path to the root documentation page of a Backstage entity can be constructed as follows:
+
+/docs/<namespace>/<kind>/<name>/
+
+The response will be formatted as Markdown.
+`,
+    schema: z.object({
+      location: z.string().describe('Location path of the documentation'),
+    }),
+    func: async ({ location }, _, toolConfig) => {
+      const credentials = toolConfig?.configurable!
+        .credentials as BackstageCredentials;
+
+      const url = new URL(
+        `${await discoveryApi.getBaseUrl('techdocs')}/static${location}`,
+      );
+
+      const pageUrl = `${url.origin}${url.pathname}`;
+
+      const { token } = await auth.getPluginRequestToken({
+        onBehalfOf: credentials,
+        targetPluginId: 'techdocs',
+      });
+      const response = await fetch(
+        `${pageUrl.endsWith('/') ? pageUrl : `${pageUrl}/`}index.html`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      const html = await response.text();
+
+      const root = parse(html);
+
+      const container = root.querySelector('.md-content');
+
+      if (!container) {
+        throw new Error('Failed to parse TechDocs page');
+      }
+
+      const turndownService = new TurndownService();
+
+      return turndownService.turndown(container.outerHTML);
+    },
+  });
+}

--- a/plugins/genai/backend/src/tools/techDocsSearchTool.ts
+++ b/plugins/genai/backend/src/tools/techDocsSearchTool.ts
@@ -18,6 +18,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
+import { SearchResultSet } from '@backstage/plugin-search-common';
 
 export function createBackstageTechDocsSearchTool(
   discoveryApi: DiscoveryService,
@@ -50,7 +51,16 @@ export function createBackstageTechDocsSearchTool(
           Authorization: `Bearer ${token}`,
         },
       });
-      return response.text();
+      const payload = (await response.json()) as SearchResultSet;
+
+      return {
+        nextPageCursor: payload.nextPageCursor,
+        results: payload.results.map(result => ({
+          location: result.document.location,
+          title: result.document.title,
+          text: result.document.text,
+        })),
+      };
     },
   });
 }

--- a/plugins/genai/docs/tools.md
+++ b/plugins/genai/docs/tools.md
@@ -9,6 +9,7 @@ The term "tool use" or "function calling" describes a mechanism where an LLM is 
 | (built-in) | `backstageCatalogSearch`  | Search the Backstage catalog using the Search API                    |
 |            | `backstageEntity`         | Retrieve information about a specific entity through the Catalog API |
 |            | `backstageTechDocsSearch` | Search TechDocs documentation using the Search API                   |
+|            | `backstageTechDocsRead`   | Reads a specific page of TechDocs documentation                      |
 
 ## Creating tools
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,11 +3054,13 @@ __metadata:
     "@backstage/plugin-auth-backend": "npm:^0.22.3"
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.1.2"
     "@backstage/plugin-catalog-node": "npm:^1.14.0"
+    "@backstage/plugin-search-common": "npm:^1.2.19"
     "@langchain/core": "npm:0.3.57"
     "@modelcontextprotocol/sdk": "npm:^1.12.3"
     "@types/express": "npm:*"
     "@types/lodash": "npm:^4"
     "@types/supertest": "npm:^2.0.12"
+    "@types/turndown": "npm:^5.0.5"
     "@types/uuid": "npm:^10"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -3066,7 +3068,9 @@ __metadata:
     knex: "npm:^3.1.0"
     lodash: "npm:^4.17.21"
     msw: "npm:^1.0.0"
+    node-html-parser: "npm:^7.0.1"
     supertest: "npm:^6.2.4"
+    turndown: "npm:^7.2.0"
     uuid: "npm:^10.0.0"
     zod: "npm:^3.23.8"
   languageName: unknown
@@ -6297,6 +6301,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@backstage/config@npm:1.3.3"
+  dependencies:
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
+    ms: "npm:^2.1.3"
+  checksum: 10c0/71f6bb34fad63a9801a71211b85b67f1e93b6d4f072a6a59da3692ff1e6f5b73973cc5969b3263d2afc67b04c22aeebe3a68fcd5fc5657933071c1a5987929f2
+  languageName: node
+  linkType: hard
+
 "@backstage/core-app-api@npm:^1.15.2":
   version: 1.15.2
   resolution: "@backstage/core-app-api@npm:1.15.2"
@@ -8303,6 +8318,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@backstage/plugin-permission-common@npm:0.9.1"
+  dependencies:
+    "@backstage/config": "npm:^1.3.3"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
+    cross-fetch: "npm:^4.0.0"
+    uuid: "npm:^11.0.0"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.20.4"
+  checksum: 10c0/702452feccd24bcefe7f50c2d6b87ec8b85cd9122738102ba35b3f507291b4896fb51a002bcbd6f4209e4017535c9a3f5f3ff3ea7ec9b20b4213bc4cdcce5a07
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.10.0":
   version: 0.10.0
   resolution: "@backstage/plugin-permission-node@npm:0.10.0"
@@ -8961,6 +8991,16 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:^0.9.0"
     "@backstage/types": "npm:^1.2.1"
   checksum: 10c0/eb8b1d8da4f2bfa5b83acfd0d07f1b421a59799ffa7c822f04826f86fbefd7b56fb9ca0bd30b07cfb030529912c5739b124b8adf44dfe250a597477dc373aa0c
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.19":
+  version: 1.2.19
+  resolution: "@backstage/plugin-search-common@npm:1.2.19"
+  dependencies:
+    "@backstage/plugin-permission-common": "npm:^0.9.1"
+    "@backstage/types": "npm:^1.2.1"
+  checksum: 10c0/3d474fcce2edeb9fc4fae7eeb427af6ed24235e5aa45d1bff12993423d8c94ac4d9a273f699eedd847589d1a9317d74d804f4d8fdcd6baeabd87fb1c2d216490
   languageName: node
   linkType: hard
 
@@ -12204,6 +12244,13 @@ __metadata:
   version: 2.0.1
   resolution: "@microsoft/fetch-event-source@npm:2.0.1"
   checksum: 10c0/38c69e9b9990e6cee715c7bbfa2752f943b42575acadb36facf19bb831f1520c469f854277439154258e0e1dc8650cc85038230d1f451e3f6b62e8faeaa1126c
+  languageName: node
+  linkType: hard
+
+"@mixmark-io/domino@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mixmark-io/domino@npm:2.2.0"
+  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
   languageName: node
   linkType: hard
 
@@ -19055,6 +19102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/turndown@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "@types/turndown@npm:5.0.5"
+  checksum: 10c0/d6b4f8451caf72399f36f810461baf5f3b5e958ff216388bb3324a9949079daad31d970a28a140b3571db8793908396e757329334f5dc8bcff414698b8c31113
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:^2, @types/unist@npm:^2.0.0":
   version: 2.0.10
   resolution: "@types/unist@npm:2.0.10"
@@ -23595,6 +23649,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-select@npm:^5.1.0":
+  version: 5.2.2
+  resolution: "css-select@npm:5.2.2"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+    css-what: "npm:^6.1.0"
+    domhandler: "npm:^5.0.2"
+    domutils: "npm:^3.0.1"
+    nth-check: "npm:^2.0.1"
+  checksum: 10c0/d79fffa97106007f2802589f3ed17b8c903f1c961c0fc28aa8a051eee0cbad394d8446223862efd4c1b40445a6034f626bb639cf2035b0bfc468544177593c99
+  languageName: node
+  linkType: hard
+
 "css-tree@npm:^1.1.2, css-tree@npm:^1.1.3":
   version: 1.1.3
   resolution: "css-tree@npm:1.1.3"
@@ -23619,6 +23686,13 @@ __metadata:
   version: 6.1.0
   resolution: "css-what@npm:6.1.0"
   checksum: 10c0/a09f5a6b14ba8dcf57ae9a59474722e80f20406c53a61e9aedb0eedc693b135113ffe2983f4efc4b5065ae639442e9ae88df24941ef159c218b231011d733746
+  languageName: node
+  linkType: hard
+
+"css-what@npm:^6.1.0":
+  version: 6.2.2
+  resolution: "css-what@npm:6.2.2"
+  checksum: 10c0/91e24c26fb977b4ccef30d7007d2668c1c10ac0154cc3f42f7304410e9594fb772aea4f30c832d2993b132ca8d99338050866476210316345ec2e7d47b248a56
   languageName: node
   linkType: hard
 
@@ -24647,6 +24721,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-serializer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dom-serializer@npm:2.0.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.2"
+    entities: "npm:^4.2.0"
+  checksum: 10c0/d5ae2b7110ca3746b3643d3ef60ef823f5f078667baf530cec096433f1627ec4b6fa8c072f09d079d7cda915fd2c7bc1b7b935681e9b09e591e1e15f4040b8e2
+  languageName: node
+  linkType: hard
+
 "domain-browser@npm:^1.1.1":
   version: 1.2.0
   resolution: "domain-browser@npm:1.2.0"
@@ -24654,7 +24739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domelementtype@npm:^2.0.1, domelementtype@npm:^2.2.0":
+"domelementtype@npm:^2.0.1, domelementtype@npm:^2.2.0, domelementtype@npm:^2.3.0":
   version: 2.3.0
   resolution: "domelementtype@npm:2.3.0"
   checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
@@ -24676,6 +24761,15 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: 10c0/5c199c7468cb052a8b5ab80b13528f0db3d794c64fc050ba793b574e158e67c93f8336e87fd81e9d5ee43b0e04aea4d8b93ed7be4899cb726a1601b3ba18538b
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+  checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
   languageName: node
   linkType: hard
 
@@ -24706,6 +24800,17 @@ __metadata:
     domelementtype: "npm:^2.2.0"
     domhandler: "npm:^4.2.0"
   checksum: 10c0/d58e2ae01922f0dd55894e61d18119924d88091837887bf1438f2327f32c65eb76426bd9384f81e7d6dcfb048e0f83c19b222ad7101176ad68cdc9c695b563db
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^3.0.1":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
+  dependencies:
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10c0/47938f473b987ea71cd59e59626eb8666d3aa8feba5266e45527f3b636c7883cca7e582d901531961f742c519d7514636b7973353b648762b2e3bedbf235fada
   languageName: node
   linkType: hard
 
@@ -24987,7 +25092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.4.0, entities@npm:^4.5.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -28253,7 +28358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"he@npm:^1.2.0":
+"he@npm:1.2.0, he@npm:^1.2.0":
   version: 1.2.0
   resolution: "he@npm:1.2.0"
   bin:
@@ -33962,6 +34067,16 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10c0/abddfff7d873312e4ed4a5fb75ce893a5c4fb69e7fcb1dfa71c28a6b92a7f1ef6b62790dffb39181b5a82728ba8f2f32d229cf8cbe66769fe02cea7db4a555aa
+  languageName: node
+  linkType: hard
+
+"node-html-parser@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "node-html-parser@npm:7.0.1"
+  dependencies:
+    css-select: "npm:^5.1.0"
+    he: "npm:1.2.0"
+  checksum: 10c0/70a4d6db83340e1c93be3c9d28b924e8a2d8c53e085805d9a4916132c56e76e105fedc2201682ff20e0af0468893d0f77ecaa69865b78206b02982d0b4a649a4
   languageName: node
   linkType: hard
 
@@ -41413,6 +41528,15 @@ __metadata:
   version: 0.0.6
   resolution: "tunnel@npm:0.0.6"
   checksum: 10c0/e27e7e896f2426c1c747325b5f54efebc1a004647d853fad892b46d64e37591ccd0b97439470795e5262b5c0748d22beb4489a04a0a448029636670bfd801b75
+  languageName: node
+  linkType: hard
+
+"turndown@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "turndown@npm:7.2.0"
+  dependencies:
+    "@mixmark-io/domino": "npm:^2.2.0"
+  checksum: 10c0/6abcdcdf9d35cd79d7a8100a7de1d2226b921d5bd99e73ac14a7ead39c059978f519378913375efb04c68bcfc40f7ffe2dee0ce9ae4d54dc1235b12856a78d4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change

The initial implementation of the GenAI TechDocs tool had some issues:

1. The raw API response was being returned with lots of extraneous information, wasting tokens
2. There was no way to easily inspect an entire page based on the results

### Description of changes

The TechDocs search response is now explicitly trimmed down to only contain:

1. Page cursor
2. Title, text and location of search results

A new tool has also been added to read a specific page of TechDocs documentation. It does this by reading the static HTML via the TechDocs API based on the `location` property, which makes it work well with search results. The response is converted to Markdown to reduce token count while retaining structure. The original Markdown source is not retained when publishing TechDocs so it would take a more custom solution to use that directly.

### Description of how you validated changes

Manual testing

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
