### PR TITLE
feat: Allow config provider to generate hashed entity names

### DIFF
--- a/plugins/core/catalog-config/README.md
+++ b/plugins/core/catalog-config/README.md
@@ -45,6 +45,7 @@ providers:
       accountId: # [OPTIONAL] AWS account ID to use to access AWS Config API
       region: # [OPTIONAL] AWS region to use to access AWS Config API
       aggregator: # [OPTIONAL] The name of the AWS Config aggregator
+      hashEntityNames: # [OPTIONAL] Generated entity names will always be hashes of the ARN
       filters: # Filter the resources queried from AWS Config API
         tags: # [OPTIONAL] Match by tags on the AWS resources
           - key: 'component' # Only retrieve resources that have a 'component' tag

--- a/plugins/core/catalog-config/config.d.ts
+++ b/plugins/core/catalog-config/config.d.ts
@@ -43,6 +43,12 @@ export interface Config {
            */
           accountId?: string;
           /**
+           * (Optional) Enable hashed entity names to prevent length > 63 characters.
+           * If not set, entity names are not hashed
+           * @see https://github.com/backstage/backstage/blob/master/packages/integration-aws-node/README.md
+           */
+          hashEntityNames?: boolean;
+          /**
            * (Required) Filters to apply in AWS Config query
            */
           filters: {

--- a/plugins/core/catalog-config/src/providers/AwsConfigInfrastructureProvider.ts
+++ b/plugins/core/catalog-config/src/providers/AwsConfigInfrastructureProvider.ts
@@ -198,9 +198,18 @@ export class AwsConfigInfrastructureProvider
   }
 
   async resourceToEntity(resource: AwsConfigResource): Promise<Entity> {
-    const resourceName = resource.resourceName
-      ? resource.resourceName.replace(':', '-')
-      : SHA256(resource.arn).toString().slice(0, 63);
+    let resourceName: string;
+    let resourceTitle: string | undefined;
+
+    if (this.config.hashEntityNames) {
+      resourceName = SHA256(resource.arn).toString().slice(0, 63);
+
+      resourceTitle = resource.resourceName;
+    } else {
+      resourceName = resource.resourceName
+        ? resource.resourceName.replace(':', '-')
+        : SHA256(resource.arn).toString().slice(0, 63);
+    }
 
     const resourceResult: Entity = {
       apiVersion: 'backstage.io/v1alpha1',
@@ -214,6 +223,7 @@ export class AwsConfigInfrastructureProvider
           'aws.amazon.com/region': resource.awsRegion!,
         },
         name: resourceName,
+        title: resourceTitle,
         description: `AWS Config Resource ${resource.resourceType} ${
           resource.resourceName || resource.resourceId
         }`,

--- a/plugins/core/catalog-config/src/providers/config.ts
+++ b/plugins/core/catalog-config/src/providers/config.ts
@@ -58,6 +58,7 @@ function readAwsInfrastructureConfig(
   const aggregator = config.getOptionalString('aggregator');
   const accountId = config.getOptionalString('accountId');
   const region = config.getOptionalString('region');
+  const hashEntityNames = config.getOptionalBoolean('hashEntityNames') ?? false;
 
   const options = config.has('options')
     ? readAwsInfrastructureOptionsConfig(config.getConfig('options'))
@@ -70,6 +71,7 @@ function readAwsInfrastructureConfig(
     filters,
     transform,
     aggregator,
+    hashEntityNames,
     options,
   };
 }

--- a/plugins/core/catalog-config/src/providers/types.ts
+++ b/plugins/core/catalog-config/src/providers/types.ts
@@ -20,6 +20,7 @@ export type AwsInfrastructureConfig = {
   filters: FilterDefinition;
   transform?: TransformDefinition;
   aggregator?: string;
+  hashEntityNames: boolean;
   options?: AwsInfrastructureConfigOptions;
 };
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #385 #364

### Reason for this change

Currently the Config entity provider generates names using either the resource name from Config or if that is missing a hash of the ARN trimmed to maximum of 63 characters.

See the linked issues above for various problems with this approach.

### Description of changes

Adds a flag `hashEntityNames` to the provider configuration schema that will trigger the provider to always generate entity names using a hash of the ARN. This retains the default behavior until the impact of this change can be better determined.

### Description of how you validated changes

Unit tests

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
