### PR TITLE
fix(core): use logger instead of logStream in scaffolder-actions

### DIFF
--- a/plugins/core/scaffolder-actions/src/actions/cloudcontrol/create.ts
+++ b/plugins/core/scaffolder-actions/src/actions/cloudcontrol/create.ts
@@ -140,7 +140,7 @@ export const createAwsCloudControlCreateAction = (options: {
         return;
       }
 
-      ctx.logStream.write(
+      ctx.logger.info(
         `Waiting ${maxWaitTime} seconds for resource creation...`,
       );
 
@@ -159,7 +159,7 @@ export const createAwsCloudControlCreateAction = (options: {
 
       const identifier = resourceRequest.ProgressEvent?.Identifier;
 
-      ctx.logStream.write(
+      ctx.logger.info(
         `Resource creation succeeded, returning identifier ${identifier}`,
       );
 


### PR DESCRIPTION
### Reason for this change

`ctx.logStream.write` is causing the following error:

```
2025-08-12T10:39:37.000Z Beginning step Create S3 Bucket
2025-08-12T10:39:37.000Z TypeError: Cannot read properties of undefined (reading 'write')
    at Object.handler (/workspaces/backstage-app/backstage/node_modules/@aws/aws-core-plugin-for-backstage-scaffolder-actions/src/actions/cloudcontrol/create.ts:143:21)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async NunjucksWorkflowRunner.executeStep (/workspaces/backstage-app/backstage/node_modules/@backstage/plugin-scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts:373:9)
    at async NunjucksWorkflowRunner.execute (/workspaces/backstage-app/backstage/node_modules/@backstage/plugin-scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts:514:9)
    at async TaskWorker.runOneTask (/workspaces/backstage-app/backstage/node_modules/@backstage/plugin-scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts:205:26)
    at async run (/workspaces/backstage-app/backstage/node_modules/p-queue/dist/index.js:163:29)
```

With this step defined in a template:

```yaml
    - id: create-s3-bucket
      name: Create S3 Bucket
      action: aws:cloudcontrol:create
      input:
        typeName: 'AWS::S3::Bucket'
        desiredState: '{"BucketName": "pudzian-backstage-${{ parameters.name }}"}'
        region: 'eu-west-1'
        wait: true
        maxWaitTime: 60
```

### Description of changes

I've switched to `logger.info` (which is available in [ActionContext](https://backstage.io/docs/reference/plugin-scaffolder-node.actioncontext/))

It seems that `logStream` was completely removed in [ddb0939b4a23ca0c4254a95abef12c1fe2029b44](https://github.com/backstage/backstage/commit/ddb0939b4a23ca0c4254a95abef12c1fe2029b44#diff-92bfcc61926f47739c39bc18e85540d81b7cd18ad3ec8cf4ee132278cd407a14).
Previously it was deprecated, and [it was suggested to use `logger` instead](https://github.com/backstage/backstage/commit/ddb0939b4a23ca0c4254a95abef12c1fe2029b44#diff-92bfcc61926f47739c39bc18e85540d81b7cd18ad3ec8cf4ee132278cd407a14L103-L104):

```ts
      /** @deprecated - use `ctx.logger` instead */
      logStream: Writable;
```

### Description of how you validated changes

I've run the tests via `yarn test` and tested the built plugin with my Backstage app

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
