### PR TITLE
fix: update Amazon ECR plugin config keys to reflect the documentation

### DIFF
--- a/plugins/ecr/backend/src/config/config.ts
+++ b/plugins/ecr/backend/src/config/config.ts
@@ -19,8 +19,8 @@ const DEFAULT_FINDINGS_LIMIT = 100;
 
 export function readEcrConfig(config: Config): EcrConfig {
   return {
-    maxImages: config.getOptionalNumber('maxImages') || DEFAULT_IMAGES_LIMIT,
+    maxImages: config.getOptionalNumber('aws.ecr.maxImages') || DEFAULT_IMAGES_LIMIT,
     maxScanFindings:
-      config.getOptionalNumber('maxScanFindings') || DEFAULT_FINDINGS_LIMIT,
+      config.getOptionalNumber('aws.ecr.maxScanFindings') || DEFAULT_FINDINGS_LIMIT,
   };
 }


### PR DESCRIPTION
### Issue 

#581 

### Reason for this change

The current keys used to read the ECR configuration do not match the documentation.

### Description of changes

Prefix all ECR configuration keys with `aws.ecr.`

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
