### PR TITLE
Bumped `@backstage/integration-aws-node` to `0.2.0`

### DIFF
--- a/plugins/core/catalog-config/package.json
+++ b/plugins/core/catalog-config/package.json
@@ -37,7 +37,7 @@
     "@backstage/backend-plugin-api": "^1.4.3",
     "@backstage/catalog-model": "^1.7.5",
     "@backstage/config": "^1.3.3",
-    "@backstage/integration-aws-node": "^0.1.17",
+    "@backstage/integration-aws-node": "^0.2.0",
     "@backstage/plugin-catalog-backend-module-incremental-ingestion": "^0.7.4",
     "@backstage/types": "^1.2.2",
     "crypto-js": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,7 +2542,7 @@ __metadata:
     "@backstage/catalog-model": "npm:^1.7.5"
     "@backstage/cli": "npm:^0.34.3"
     "@backstage/config": "npm:^1.3.3"
-    "@backstage/integration-aws-node": "npm:^0.1.17"
+    "@backstage/integration-aws-node": "npm:^0.2.0"
     "@backstage/plugin-catalog-backend-module-incremental-ingestion": "npm:^0.7.4"
     "@backstage/types": "npm:^1.2.2"
     "@types/crypto-js": "npm:^4"
@@ -4303,6 +4303,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "@backstage/config@npm:1.3.8"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10c0/bd9e1fdd7ab8e56a9814a7f67502ed69f9abd0f014dae44d253a6a02c0c6bf844451d037afa991b200fc09d89e7195593bd5a9459357dafd8101dc826e664dec
+  languageName: node
+  linkType: hard
+
 "@backstage/core-app-api@npm:^1.19.0, @backstage/core-app-api@npm:^1.19.2, @backstage/core-app-api@npm:^1.19.3, @backstage/core-app-api@npm:^1.19.4":
   version: 1.19.4
   resolution: "@backstage/core-app-api@npm:1.19.4"
@@ -4591,6 +4602,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/errors@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/errors@npm:1.3.1"
+  dependencies:
+    "@backstage/types": "npm:^1.2.2"
+    serialize-error: "npm:^8.0.1"
+  checksum: 10c0/b342551f5337f17bcc6d412868f6274509d657cc6037fbb5af96d42156c24c2419e72fd711136e42d05245bd4e5c5d8fe9cd54f89f260d9285a073c28cca0261
+  languageName: node
+  linkType: hard
+
 "@backstage/eslint-plugin@npm:^0.2.0":
   version: 0.2.0
   resolution: "@backstage/eslint-plugin@npm:0.2.0"
@@ -4757,6 +4778,21 @@ __metadata:
     "@backstage/config": "npm:^1.3.6"
     "@backstage/errors": "npm:^1.2.7"
   checksum: 10c0/803ba256051c6a9f7e45ba199e6d219e99ce5fd0e6145ec3ad9ff18dc333c4b148aac7a8cc1a67ea48f0a5f7e461271949284d9c5101bd1b4f317043d5f3a87b
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-aws-node@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@backstage/integration-aws-node@npm:0.2.0"
+  dependencies:
+    "@aws-sdk/client-sts": "npm:^3.350.0"
+    "@aws-sdk/credential-provider-node": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@aws-sdk/util-arn-parser": "npm:^3.310.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+  checksum: 10c0/338b2e271c16539d342c39af70228b078847ad522a65bec021e07a653587969eccff1281463675f8dd485ad043e9b618b36befbead4cb145eb2206234aabc82c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Reason for this change

Bumped `@backstage/integration-aws-node` to `0.2.0` in order to use `webIdentityTokenFile` added in that version: https://github.com/backstage/backstage/blob/master/packages/integration-aws-node/CHANGELOG.md#020.
### Description of changes

Bumped `@backstage/integration-aws-node` to `0.2.0`, all the dependant versions are within their current ranges.

### Description of how you validated changes

Tested again a sample AWS Account.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
