### PR TITLE
fix(ecr): add frontend config schema for aws.sso.subdomain

### DIFF
--- a/plugins/ecr/frontend/config.d.ts
+++ b/plugins/ecr/frontend/config.d.ts
@@ -1,0 +1,10 @@
+export interface Config {
+  aws?: {
+    sso?: {
+      /**
+       * @visibility frontend
+       */
+      subdomain: string;
+    };
+  };
+}

--- a/plugins/ecr/frontend/package.json
+++ b/plugins/ecr/frontend/package.json
@@ -74,6 +74,8 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
Fixes #605.

The ECR frontend already reads `aws.sso.subdomain` to build Identity Center shortcut links for the **Tag** column, but the plugin shipped no config schema. Backstage only exposes config to the frontend when a plugin declares it `@visibility frontend`, so ECR-only deployments (without CodeBuild/CodePipeline, which do declare it) had the value stripped — and Tag links fell back to the default AWS console.

Adds `config.d.ts` and the `configSchema` registration, mirroring the CodeBuild/CodePipeline plugins. No runtime logic change.
