### PR TITLE
chore(deps): bump uuid to v11 and drop @types/uuid

### DIFF
--- a/plugins/genai/backend/package.json
+++ b/plugins/genai/backend/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.21",
     "node-html-parser": "^7.0.1",
     "turndown": "^7.2.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -66,7 +66,6 @@
     "@types/lodash": "^4",
     "@types/supertest": "^2.0.12",
     "@types/turndown": "^5.0.5",
-    "@types/uuid": "^10",
     "msw": "^1.0.0",
     "supertest": "^6.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,7 +2812,6 @@ __metadata:
     "@types/lodash": "npm:^4"
     "@types/supertest": "npm:^2.0.12"
     "@types/turndown": "npm:^5.0.5"
-    "@types/uuid": "npm:^10"
     express: "npm:^4.17.17"
     express-promise-router: "npm:^4.1.0"
     jsonschema: "npm:^1.5.0"
@@ -2822,7 +2821,7 @@ __metadata:
     node-html-parser: "npm:^7.0.1"
     supertest: "npm:^6.2.4"
     turndown: "npm:^7.2.0"
-    uuid: "npm:^10.0.0"
+    uuid: "npm:^11.0.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -14929,7 +14928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^10, @types/uuid@npm:^10.0.0":
+"@types/uuid@npm:^10.0.0":
   version: 10.0.0
   resolution: "@types/uuid@npm:10.0.0"
   checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
@@ -37235,6 +37234,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/eab18c27fe4ab9fb9709a5d5f40119b45f2ec8314f8d4cf12ce27e4c6f4ffa4a6321dc7db6c515068fa373c075b49691ba969f0010bf37f44c37ca40cd6bf7fe
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.0.0":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the genai backend's runtime `uuid` to `^11` and removes `@types/uuid` (uuid v11 ships its own types).

Supersedes #684, which bumped only `@types/uuid` to the v11 stub while runtime `uuid` stayed at v10 — that breaks `tsc` with `TS7016: Could not find a declaration file for module 'uuid'`. `yarn tsc` passes with this change.
